### PR TITLE
Show new HDF5 page in deployed site

### DIFF
--- a/ch01data/070hdf5.ipynb
+++ b/ch01data/070hdf5.ipynb
@@ -269,6 +269,9 @@
   }
  ],
  "metadata": {
+  "jekyll": {
+    "display_name": "Scientific File Formats"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",


### PR DESCRIPTION
New notebooks (#160) need additional metadata, or they won't be included in the deployed pages...