### PR TITLE
Removes blank space that makes cython magic load to fail

### DIFF
--- a/ch08performance/040cython.ipynb
+++ b/ch08performance/040cython.ipynb
@@ -88,7 +88,7 @@
    },
    "outputs": [],
    "source": [
-    "%load_ext Cython "
+    "%load_ext Cython"
    ]
   },
   {


### PR DESCRIPTION
It should render all properly now.