### PR TITLE
Fix link and make section headings consistent

### DIFF
--- a/ch05construction/09patterns.ipynb
+++ b/ch05construction/09patterns.ipynb
@@ -93,8 +93,8 @@
     "We'll just show a few in this session:\n",
     "\n",
     "* [Factory Method](#Factory-Pattern)\n",
-    "* [Builder](#Builder)\n",
-    "* [Strategy](#Strategy)\n",
+    "* [Builder](#Builder-Pattern)\n",
+    "* [Strategy](#Strategy-Pattern)\n",
     "* [Model-View-Controller](#Model-View-Controller)"
    ]
   },
@@ -401,7 +401,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Builder"
+    "## Builder Pattern"
    ]
   },
   {


### PR DESCRIPTION
Link to Strategy Pattern section was previously not working.