### PR TITLE
Issue #184: Remove links to obsolete CDT Medical Imaging website.

### DIFF
--- a/index.md
+++ b/index.md
@@ -22,8 +22,6 @@ your computer.
 
 Members of doctoral training schools, or Masters courses who offer this module as part of their programme should register through their course organisers.
 
-Further information is on the [UCL EPSRC Centre for Doctoral Training in Medical Imaging](http://medicalimaging-cdt.ucl.ac.uk/programmes) website.
-
 This course may not be audited.
 
 ## Synopsis


### PR DESCRIPTION
I thought about changing the URL to point to the new i4Health CDT, but decided against this, as its not really relevant. People are now registering from all over college.  Students would be expected to find the module in the UCL Module Catalogue, or by reputation within their department. So, the link itself is unnecessary.