### PR TITLE
Pause building PDF and zipping notebooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ master.zip: Makefile
 	rm -f master.zip
 	wget https://github.com/UCL-RITS/indigo-jekyll/archive/master.zip
 
-ready: indigo $(HTMLS) notes.pdf notebooks.zip
+ready: indigo $(HTMLS) # notes.pdf notebooks.zip
 
 indigo-jekyll-master: Makefile master.zip
 	rm -rf indigo-jekyll-master

--- a/index.md
+++ b/index.md
@@ -137,4 +137,5 @@ program. That means that you may find supplementary python content useful.
 
 You can find the course notes as HTML via the navigation bar to the left.
 
-The [notes](notes.pdf) are also available in  a printable pdf format.
+The [notes](notes.pdf) are also available in a printable pdf format.
+(**temporarily unavailable!**)


### PR DESCRIPTION
The PDF was breaking the Travis build and needs investigation.
The zip containing the notebooks is not linked from anywhere, can be retrieved from GitHub and is taking up a lot of space.
Stop them temporarily, at least.