### PR TITLE
Include greenpath notebook on website again

### DIFF
--- a/ch00python/010exemplar.ipynb
+++ b/ch00python/010exemplar.ipynb
@@ -964,6 +964,9 @@
   }
  ],
  "metadata": {
+  "jekyll": {
+   "display_name": "An example program"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 1


### PR DESCRIPTION
Metadata accidentally removed in #183, which excluded it from the Jekyll pages!