### PR TITLE
jekyll's updates

### DIFF
--- a/.github/workflows/build_site.yml
+++ b/.github/workflows/build_site.yml
@@ -11,12 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2 # FIXME: add pip + latex + gems
+      - uses: actions/cache@v2 # FIXME: add apt(latex)
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
           restore-keys: |
             ${{ runner.os }}-gems-
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '.github/python/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install TeXLive
         uses: DanySK/setup-texlive-action@0.1.1
       - id: setup-python

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'jekyll', '~> 3.1.6'
-gem 'redcarpet', '~> 3.5.0'
+gem 'jekyll', '~> 4.2.1'
+gem 'kramdown', '~> 2.3.1'

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'jekyll', '~> 4.2.1'
 gem 'kramdown', '~> 2.3.1'
+gem "jekyll-remote-theme"

--- a/Makefile
+++ b/Makefile
@@ -59,25 +59,7 @@ notes.tex: combined.ipynb $(PNGS) Makefile
 notebooks.zip: ${NBV2}
 	zip -r notebooks $^
 
-master.zip: Makefile
-	rm -f master.zip
-	wget https://github.com/UCL-RITS/indigo-jekyll/archive/master.zip
-
-ready: indigo $(HTMLS) # notes.pdf notebooks.zip
-
-indigo-jekyll-master: Makefile master.zip
-	rm -rf indigo-jekyll-master
-	unzip master.zip
-	touch indigo-jekyll-master
-
-indigo: indigo-jekyll-master Makefile
-	cp -r indigo-jekyll-master/indigo/images .
-	cp -r indigo-jekyll-master/indigo/js .
-	cp -r indigo-jekyll-master/indigo/css .
-	cp -r indigo-jekyll-master/indigo/_includes .
-	cp -r indigo-jekyll-master/indigo/_layouts .
-	cp -r indigo-jekyll-master/indigo/favicon* .
-	touch indigo
+ready:  $(HTMLS) # notes.pdf notebooks.zip
 
 plantuml.jar:
 	wget http://sourceforge.net/projects/plantuml/files/plantuml.jar/download -O plantuml.jar

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ INFO[0001]   ☁  git clone 'https://github.com/helaili/jekyll-action' # ref=v2
 Alternatively, if you want to only run the jekyll build step once you've run the whole action, you can use the official jekyll containers with:
 
 ```bash
-$ docker run --rm --volume="$PWD:/srv/jekyll" --volume="$PWD/vendor/bundle:/usr/local/bundle" -p 4000:4000 -it jekyll/jekyll:3.1.6 jekyll serve
+$ docker run --rm --volume="$PWD:/srv/jekyll" --volume="$PWD/vendor/bundle:/usr/local/bundle" -p 4000:4000 -it jekyll/jekyll:latest jekyll serve
 ```
 
 and open http://localhost:4000/rsd-engineeringcourse (or the link provided).

--- a/_config.yml
+++ b/_config.yml
@@ -20,9 +20,8 @@ crumbs:
   - link: http://www.ucl.ac.uk/isd/services/research-it/training
     text: Training
 
-markdown: redcarpet
-redcarpet:
-  extensions: ["strikethrough","tables"]
+kramdown:
+  hard_wrap: false
 
 
 include: # NOTE: This is not a path, but the directories name, wherever they are

--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,8 @@ defaults:
 
 baseurl: /rsd-engineeringcourse
 
+remote_theme: dpshelio/indigo-jekyll
+
 crumbs:
   - link: http://www.ucl.ac.uk/ISD
     text: ISD
@@ -23,6 +25,8 @@ crumbs:
 kramdown:
   hard_wrap: false
 
+plugins:
+  - jekyll-remote-theme
 
 include: # NOTE: This is not a path, but the directories name, wherever they are
   - _static


### PR DESCRIPTION
- Updates Jekyll to the latest version.
- Uses now kramdown as the markdown converter.
- This includes changes on how we manage the theme (via remote-themes) that at the moment points to my fork - till I'm sure we can push these changes on the theme itself.