### PR TITLE
Update nbconvert

### DIFF
--- a/.github/python/requirements.txt
+++ b/.github/python/requirements.txt
@@ -1,6 +1,5 @@
 -r ../../requirements.txt
 git+https://github.com/jakevdp/JSAnimation.git
-nbconvert==5.6.1
 # https://github.com/jupyter/nbgrader/issues/1373#issuecomment-702798246
 jupyter-client==6.1.12
 # https://github.com/jupyter/jupyter_client/issues/637

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ default: _site
 %.png: %.uml plantuml.jar Makefile
 	java -Djava.awt.headless=true -jar plantuml.jar -p < $< > $@
 
-%.html: %.nbconvert.ipynb Makefile jekyll.tpl
-	jupyter nbconvert --to html  --template jekyll.tpl --stdout $< > $@
+%.html: %.nbconvert.ipynb Makefile jekyll_template
+	jupyter nbconvert --to html  --template jekyll_template --stdout $< > $@
 
 %.v2.ipynb: %.nbconvert.ipynb
 	jupyter nbconvert --to notebook --nbformat 2 --stdout $< > $@

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ default: _site
 	jupyter nbconvert --to notebook --allow-errors --ExecutePreprocessor.timeout=120 --execute --stdout $< > $@
 
 notes.pdf: combined.ipynb $(PNGS) Makefile
-	jupyter nbconvert --to pdf --template latex.tplx $<
+	jupyter nbconvert --to pdf --template latex_template $<
 	mv combined.pdf notes.pdf
 
 combined.ipynb: $(EXECUTED)
@@ -53,7 +53,7 @@ combined.ipynb: $(EXECUTED)
 	sed -i -e 's/\.svg/\.png/g' $@
 
 notes.tex: combined.ipynb $(PNGS) Makefile
-	jupyter nbconvert --to latex --template latex.tplx $<
+	jupyter nbconvert --to latex --template latex_template $<
 	mv combined.tex notes.tex
 
 notebooks.zip: ${NBV2}

--- a/ch03tests/01testingbasics.ipynb
+++ b/ch03tests/01testingbasics.ipynb
@@ -199,10 +199,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.4"
-  },
-  "widgets": {
-   "state": {},
-   "version": "1.1.2"
   }
  },
  "nbformat": 4,

--- a/ch03tests/02SaskatchewanFields.ipynb
+++ b/ch03tests/02SaskatchewanFields.ipynb
@@ -843,10 +843,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.5.3"
-  },
-  "widgets": {
-   "state": {},
-   "version": "1.1.2"
   }
  },
  "nbformat": 4,

--- a/ch03tests/03pytest.ipynb
+++ b/ch03tests/03pytest.ipynb
@@ -530,10 +530,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.6.1"
-  },
-  "widgets": {
-   "state": {},
-   "version": "1.1.2"
   }
  },
  "nbformat": 4,

--- a/ch03tests/04EnergyExample.ipynb
+++ b/ch03tests/04EnergyExample.ipynb
@@ -481,10 +481,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.5.3"
-  },
-  "widgets": {
-   "state": {},
-   "version": "1.1.2"
   }
  },
  "nbformat": 4,

--- a/ch03tests/05Mocks.ipynb
+++ b/ch03tests/05Mocks.ipynb
@@ -566,10 +566,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.3"
-  },
-  "widgets": {
-   "state": {},
-   "version": "1.1.2"
   }
  },
  "nbformat": 4,

--- a/ch03tests/06Debugger.ipynb
+++ b/ch03tests/06Debugger.ipynb
@@ -216,10 +216,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.3"
-  },
-  "widgets": {
-   "state": {},
-   "version": "1.1.2"
   }
  },
  "nbformat": 4,

--- a/ch03tests/07CI.ipynb
+++ b/ch03tests/07CI.ipynb
@@ -66,10 +66,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.6.1"
-  },
-  "widgets": {
-   "state": {},
-   "version": "1.1.2"
   }
  },
  "nbformat": 4,

--- a/ch04packaging/010Installation.ipynb
+++ b/ch04packaging/010Installation.ipynb
@@ -413,10 +413,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.5.2"
-  },
-  "widgets": {
-   "state": {},
-   "version": "1.1.2"
   }
  },
  "nbformat": 4,

--- a/ch04packaging/01Libraries.ipynb
+++ b/ch04packaging/01Libraries.ipynb
@@ -187,10 +187,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.6.2"
-  },
-  "widgets": {
-   "state": {},
-   "version": "1.1.2"
   }
  },
  "nbformat": 4,

--- a/ch04packaging/025TextFiles.ipynb
+++ b/ch04packaging/025TextFiles.ipynb
@@ -543,10 +543,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.5.2"
-  },
-  "widgets": {
-   "state": {},
-   "version": "1.1.2"
   }
  },
  "nbformat": 4,

--- a/ch04packaging/02Argparse.ipynb
+++ b/ch04packaging/02Argparse.ipynb
@@ -348,10 +348,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.5"
-  },
-  "widgets": {
-   "state": {},
-   "version": "1.1.2"
   }
  },
  "nbformat": 4,

--- a/ch04packaging/03Packaging.ipynb
+++ b/ch04packaging/03Packaging.ipynb
@@ -1479,10 +1479,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.5"
-  },
-  "widgets": {
-   "state": {},
-   "version": "1.1.2"
   }
  },
  "nbformat": 4,

--- a/ch98rubrics/PackagingTreasure.ipynb
+++ b/ch98rubrics/PackagingTreasure.ipynb
@@ -543,10 +543,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.5.2"
-  },
-  "widgets": {
-   "state": {},
-   "version": "1.1.2"
   }
  },
  "nbformat": 4,

--- a/jekyll_template/conf.json
+++ b/jekyll_template/conf.json
@@ -1,0 +1,6 @@
+{
+    "base_template": "basic",
+    "mimetypes": {
+      "text/html": true
+    }
+}

--- a/jekyll_template/index.html.j2
+++ b/jekyll_template/index.html.j2
@@ -1,4 +1,4 @@
-{%- extends 'basic.tpl' -%}
+{%- extends 'basic/index.html.j2' -%}
 {%- block header -%}
 ---
 title: {% if 'jekyll' in nb['metadata'] %} {{nb['metadata']['jekyll']['display_name']}} {% endif %}

--- a/latex_template/conf.json
+++ b/latex_template/conf.json
@@ -1,0 +1,8 @@
+{
+    "base_template": "latex",
+    "mimetypes": {
+        "text/latex": true,
+        "text/tex": true,
+        "application/pdf": true
+    }
+}

--- a/latex_template/index.tex.j2
+++ b/latex_template/index.tex.j2
@@ -5,7 +5,7 @@
 
 % Default to the notebook output style
 ((* if not cell_style is defined *))
-    ((* set cell_style = 'style_ipython.tplx' *))
+    ((* set cell_style = 'style_ipython.tex.j2' *))
 ((* endif *))
 
 % Inherit from the specified cell style.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 attrs>=17.4.0
-jinja2<3.1
-nbconvert<6.0.0
+nbconvert>=6.0.0
 ipython
 jupyter
 numpy


### PR DESCRIPTION
Fixes #186.

- Update `nbconvert` dependency (and related `jinja2` change from #213)
- Remove `"widgets"` metadata from notebooks. This was only present in some notebooks, and caused issues with newer nbconvert (but not on all notebooks where it was used!). I don't think it affects anything.
- Update our custom templates to work with the new style introduced in nbconvert 6: the Jekyll template should be okay, I haven't tried the LaTeX one.