### PR TITLE
Updates the csv section from the doctoral skills and adds pandas

### DIFF
--- a/ch01data/062csv.ipynb
+++ b/ch01data/062csv.ipynb
@@ -2,63 +2,78 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
-    "## Field and Record Data"
+    "## Field and Record Data (Tabular data)\n",
+    "\n",
+    "Tabular data, that is data that is formatted as a table with a fixed number of rows and columns, is very common in a research context. A particularly simple and also popular file format for such data is [_delimited-separated value_ files](https://en.wikipedia.org/wiki/Delimiter-separated_values)."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Separated Value Files"
+    "## Delimiter-separated values"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's carry on with our sunspots example:"
+    "Let's carry on with our sunspots example. As we saw previously the data is semicolon-separated. \n",
+    "\n",
+    "We can request the CSV file text from the URL we used previously:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'1749;01;1749.042;  96.7; -1.0;   -1;1'"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import requests\n",
-    "spots = requests.get('http://www.sidc.be/silso/INFO/snmtotcsv.php')\n",
-    "spots.text.split('\\n')[0]"
+    "# Request sunspots data from URL and extract response content as text\n",
+    "sunspots_csv_text = requests.get('http://www.sidc.be/silso/INFO/snmtotcsv.php').text\n",
+    "# Strip any leading or trailing whitespace from CSV text to skip any empty rows\n",
+    "sunspots_csv_text = sunspots_csv_text.strip()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "As a quick check we can split the text on the newline character `\\n` and print the last five entries in the resulting list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(sunspots_csv_text.split('\\n')[-5:])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We want to work programmatically with **Separated Value** files."
+    "We see that each line is a string with numeric calues separted by semicolon delimiters. We want to work programmatically with such *delimited-separated value* files."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "These are files where:\n",
+    "These are files which (typically) have\n",
     "\n",
-    "* Each **record** is on its own line\n",
-    "* Each record has multiple **fields**\n",
-    "* Fields are separated by some **separator**"
+    "* One *record* per line (row)\n",
+    "* Each record has multiple *fields* (columns)\n",
+    "* Fields are separated by some *delimiter*"
    ]
   },
   {
@@ -82,22 +97,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "CSV is also used to refer to all the different sub-kinds of separated value files, i.e. some people use CSV to refer to tab-, space- and semicolon-separated files."
+    "CSV is also sometimes used to refer to all the different sub-kinds of separated value files, i.e. some people use CSV to refer to tab-, space- and semicolon-separated files."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "CSV is not a particularly superb data format, because it forces your data model to be a list of lists. Richer file formats describe \"serialisations\" for dictionaries and for deeper-than-two nested list structures as well."
+    "CSV is not a particularly superb data format, because it forces your data model to only have two 'axes', records and fields, with each record a flat object. As we will see in the next notebook, structured file formats can be used to represent a richer array of data formats, including for example hierarchically structured data where each record may itself have an internal structure."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Nevertheless, because you can always export spreadsheets as CSV files (each row is a record, each cell is a field),\n",
-    "CSV files are very popular. "
+    "Nevertheless, because you can always export *spreadsheets* as CSV files (each cell is a field, each row is a record), CSV files are very popular. "
    ]
   },
   {
@@ -136,9 +150,242 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Python `csv` module"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "The Python standard library provides a `csv` module for reading and writing delimited-separated value files, including, as the name suggests, CSV files. As it is built-in to all Python installations, it is useful to be familiar with the `csv` module as an option for loading and saving CSV formatted data, though the CSV capabilities in third-party libraries such as [NumPy](https://numpy.org/doc/stable/reference/generated/numpy.loadtxt.html) (which we will cover later in the course) and [Pandas](https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html) are more powerful and will often be better options in practice."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import csv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Python CSV readers"
+    "The most straightforward way to read CSV files using the `csv` module is with the [`csv.reader` function](https://docs.python.org/3/library/csv.html#csv.reader). This accepts an _iterable_ object as its first argument which returns a line of delimited input for each iteration. Commonly this will be an opened file object however it can also for example be a sequence of strings which is what we will use here by using the `split` method to convert the sunspot CSV text object into a list of per-line strings. The `csv.reader` function also accepts various optional keyword arguments including importantly a `delimiter` argument to specify the character used as the delimiter separating the values in each line, with we setting this to a semicolon here. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "csv_reader = csv.reader(sunspots_csv_text.split('\\n'), delimiter=';')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The object returned by the `csv.reader` function is an iterator over the rows of the CSV file, with each row being returned as a list of the separated values in the row (with all values being read as strings by default). We can read all of the data in to a nested list-of-lists using a list comprehension:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sunspots_data = [row for row in csv_reader]\n",
+    "print(sunspots_data[-5:])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For this particular CSV file the first column corresponds to the measurement year, the second the measurement month number and the third the measurement date as a 'fractional year'. We can extract a list of the just the (fractional) years converted to floating point values using another list comprehension"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fractional_years = [float(row[2]) for row in sunspots_data]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Similarly the fourth column in the CSV file contains the monthly mean total sunspot number, which we can extract with another list comprehension"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "monthly_mean_total_sunspot_numbers = [float(row[3]) for row in sunspots_data]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can then for example use Matplotlib to create a plot of how the monthly average sunspot number varies over time, with this highlighting [the cyclic nature of sunspot activity](https://en.wikipedia.org/wiki/Solar_cycle)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from matplotlib import pyplot as plt\n",
+    "plt.plot(fractional_years, monthly_mean_total_sunspot_numbers)\n",
+    "plt.xlabel('Year')\n",
+    "plt.ylabel('Monthly mean total sunspot number');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Reading rows as dictionaries"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Accessing the values in each row by an index corresponding to their column can be unclear and prone to bugs. The `csv` module also provides the `csv.DictReader` class to allow reading each record (line) in the CSV file as a dictionary keyed by a set of field names. For the dataset we are using [we have the columns correspond to](http://www.sidc.be/silso/infosnmtot)\n",
+    "\n",
+    "```\n",
+    "Column 1-2: Gregorian calendar date\n",
+    "- Year\n",
+    "- Month\n",
+    "Column 3: Date in fraction of year.\n",
+    "Column 4: Monthly mean total sunspot number.\n",
+    "Column 5: Monthly mean standard deviation of the input sunspot numbers.\n",
+    "Column 6: Number of observations used to compute the monthly mean total sunspot number.\n",
+    "Column 7: Definitive/provisional marker. '1' indicates that the value is definitive. '0' indicates that the value is still provisional.\n",
+    "```\n",
+    "\n",
+    "We can create an instance of the `csv.DictReader` class very similarly to how we called the `csv.reader` function, but with an additional keyword argument `fieldnames` specifying a sequence of strings corresponding to the keys to associate the values in each row with. Below we also set the optional keyword argument `quoting` to the special constant `csv.QUOTE_NONNUMERIC` which causes all non-quoted values in each line to be automatically converted to floating point values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "csv_reader = csv.DictReader(\n",
+    "    sunspots_csv_text.split('\\n'),\n",
+    "    fieldnames=['year', 'month', 'fractional_year', 'mean', 'deviation', 'observations', 'definitive'],\n",
+    "    delimiter=';',\n",
+    "    quoting=csv.QUOTE_NONNUMERIC\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Similarly to previously we can now extract all the data using a list comprehension, with the difference being that each item in the constructed list is now a dictionary keyed by the field names:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sunspots_data = [record for record in csv_reader]\n",
+    "print(sunspots_data[-1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can then recreate the same plot as previously as follows, with the intention of the list comprehensions extracting the year and mean values now much more apparent"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from matplotlib import pyplot as plt\n",
+    "\n",
+    "plt.plot([r['fractional_year'] for r in sunspots_data], [r['mean'] for r in sunspots_data])\n",
+    "plt.xlabel('Year')\n",
+    "plt.ylabel('Monthly mean total sunspot number');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "#### Writing CSV files\n",
+    "\n",
+    "The `csv` module also provides functionality for writing delimiter-separated value files. The `csv.writer` function provides a simple interface for writing CSV files row by row, with the function accepting a file object (and optional keyword arugments specifying formatting options such as `delimiter`) and the returned object providing a `writerow` method to write a sequence of values to the file as a delimiter-separated string. For example we can save a table of data about the planets in the solar system as a comma-separated values file using the following code snippet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "planets_data = [\n",
+    "    ['Name', 'Mean distance from sun / AU', 'Orbit period / years', 'Mass / M🜨', 'Radius / R🜨', 'Number of satellites'],\n",
+    "    ['Mercury', 0.39, 0.24, 0.06, 0.38, 0],\n",
+    "    ['Venus', 0.72, 0.62, 0.82, 0.95, 0],\n",
+    "    ['Earth', 1., 1., 1., 1., 1],\n",
+    "    ['Mars', 1.5, 1.9, 0.11, 0.53, 2],\n",
+    "    ['Jupiter', 5.2, 12., 320., 11., 63],\n",
+    "    ['Saturn', 9.5, 29., 95., 9.4, 61],\n",
+    "    ['Uranus', 19., 84., 15., 4.1, 27],\n",
+    "    ['Neptune', 30., 170., 17., 3.9, 14],\n",
+    "]\n",
+    "\n",
+    "with open('planets_data.csv', 'w', encoding='utf-8') as f:\n",
+    "    csv_writer = csv.writer(f, delimiter=',')\n",
+    "    for row in planets_data:\n",
+    "        csv_writer.writerow(row)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A [`csv.DictWriter`](https://docs.python.org/3/library/csv.html#csv.DictWriter) class is also provided which analogously to the  `csv.DictReader` class, allows writing a CSV file using rows specified by dictionaries mapping from field names to values."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### NumPy's CSV readers"
    ]
   },
   {
@@ -146,7 +393,7 @@
    "metadata": {},
    "source": [
     "The Python standard library has a `csv` module. However, it's less powerful than the CSV capabilities in `numpy`,\n",
-    "the main scientific python library for handling data. NumPy is destributed with Anaconda and Canopy, so we recommend you just use that."
+    "the main scientific python library for handling data. NumPy is destributed with Anaconda and Canopy, so we recommend use that when available."
    ]
   },
   {
@@ -154,22 +401,21 @@
    "metadata": {},
    "source": [
     "NumPy has powerful capabilities for handling matrices, and other fun stuff, and we'll learn about these later in the course,\n",
-    "but for now, we'll just use NumPy's CSV reader, and assume it gives us lists and dictionaries, rather than its more exciting `array` type."
+    "but for now, we'll use NumPy's CSV reader, and assume it gives us lists and dictionaries, rather than its more exciting `array` type."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
-    "import requests"
+    "import numpy as np"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -185,7 +431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,26 +442,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`genfromtxt` is a powerful CSV reader. I used the `delimiter` optional argument to specify the delimeter. I could also specify\n",
-    "`names=True` if I had a first line naming fields, and `comments=#` if I had comment lines."
+    "`genfromtxt` is a powerful CSV reader. We used the `delimiter` optional argument to specify the delimeter. We could also specify\n",
+    "`names=True` if we had a first line naming fields, and `comments=#` if we had comment lines."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "96.7"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "sunspots[0][3]"
    ]
@@ -224,37 +459,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can now plot the \"Sunspot cycle\":"
+    "As before, we can now plot the \"Sunspot cycle\", note how we can specify the column directly from the data we've read."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x10f59a828>]"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXoAAAD8CAYAAAB5Pm/hAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvqOYd8AAAIABJREFUeJztnXfcHUXVx3/nKUlISG+EJJAQQggQSEIMAYK0CAHEoIKCCAgoLyBKEwRBXnhVRFFQLGg0SFOK9BJKSAgQIL33PKT3J70/9bx/3N17Z/fO7M622575fj7P57l37+zu7O7M2TNnzpxDzAyDwWAwlC5l+a6AwWAwGJLFCHqDwWAocYygNxgMhhLHCHqDwWAocYygNxgMhhLHCHqDwWAocYygNxgMhhLHCHqDwWAocYygNxgMhhKnIt8VAIBOnTpxr1698l0Ng8FgKCpmzJixhZk7+5UrCEHfq1cvTJ8+Pd/VMBgMhqKCiFbplDOmG4PBYChxjKA3GAyGEscIeoPBYChxjKA3GAyGEkdb0BNRORHNIqK3rO+9iWgKEVUR0QtE1Mza3tz6XmX93iuZqhsMBoNBhyAa/c0AFgnffwPgUWY+EsB2ANda268FsN3a/qhVzmAwGAx5QkvQE1EPABcA+Kf1nQCcBeAlq8hTAC6yPo+yvsP6/WyrvMFgMBjygK5G/wcAdwJotL53BLCDmeut72sBdLc+dwewBgCs33da5R0Q0XVENJ2IpldXV4esfv5pbGS8OG0N6hsa/QsbDAZDHvAV9ET0VQCbmXlGnCdm5tHMPISZh3Tu7Luwq2B5cfoa3PnyXIyZtCLfVTEYDAYpOitjTwXwNSI6H0ALAG0A/BFAOyKqsLT2HgDWWeXXAegJYC0RVQBoC2Br7DUvELbvqwMAbNtbm+eaGAwGgxxfjZ6Z72bmHszcC8ClACYw8+UAPgRwsVXsKgCvW5/fsL7D+n0CM3OstS4gzOyDwWAodKL40f8UwG1EVIWUDX6MtX0MgI7W9tsA3BWtigaDwWCIQqCgZsw8EcBE6/NyAEMlZQ4AuCSGuhUVJTtkMRgMRY9ZGRsRY7kxGAyFjhH0BoPBUOIYQR8TJTzfbDAYihwj6CNie90YOW8wGAoVI+gNBoOhxDGC3mAwGEocI+gjQpbfjbHcGAyGQsUI+oiYlbEGg6HQMYLeYDAYShwj6GPCeN0YDIZCxQh6g8FgKHGMoDcYDIYSxwj6mGDjd2MwGAoUI+gjYtLhGgx67DpQh51Woh5DbgkUpthgMBjCcvz97wMAVj50QZ5r0vQwGn1MGK8bg8FQqOgkB29BRFOJaA4RLSCiB6ztTxLRCiKabf0NtLYTET1GRFVENJeIBid9EfnEGG4MBkOho2O6qQFwFjPvIaJKAJOI6B3rtzuY+SVX+fMA9LX+TgLwuPXfYDAYDHlAJzk4M/Me62ul9edlqBgF4Glrv8kA2hFRt+hVNRgMBkMYtGz0RFRORLMBbAYwjpmnWD/9yjLPPEpEza1t3QGsEXZfa21zH/M6IppORNOrq6sjXEJ+ycSjN0Z6g8FQmGgJemZuYOaBAHoAGEpExwG4G8DRAL4EoAOAnwY5MTOPZuYhzDykc+fOAatdOBgbvcFgKHQCed0w8w4AHwIYycwbLPNMDYB/ARhqFVsHoKewWw9rm6HEeXPOeuw6YPykDYZCQ8frpjMRtbM+HwTgKwAW23Z3Sq0YugjAfGuXNwBcaXnfDAOwk5k3JFL7AqKpG26WbdqNHz03C3f8d06+q2IwGFzoeN10A/AUEZUj9WJ4kZnfIqIJRNQZKevFbADXW+XHAjgfQBWAfQCujr/ahYNZGZtif10DAGDdjv15ronBYHDjK+iZeS6AQZLtZynKM4AfRq+aoZgos154Zk7aYCg8zMrYmDACLoW5DwZD4WEEfUSM5SZF2s00v9UwGAwSjKA3xEI6SbpR6Q2GgsMI+pho6vHozcjGYChcjKCPiJFvKWxB32g0eoOh4DCC3hALGdNNnitiMBiyMII+Jpq6gDOTsQZD4WIEfVRs//E8VyPflJngbgZDwWIEfUSMjd7GvPAMhkLFCHpDLKS9boykN/hgRn25xwj6mGjqbdeW88brxuCHaSK5xwj6iBj/8RRk5ioMmpg2knuMoDfEQtpyY3qxwQdjusk9RtDHRtNuvOnolU38PhgMhYgR9BEh43cDQMydm996GAqf0Z8sR2OjaSi5RCfDVAsimkpEc4hoARE9YG3vTURTiKiKiF4gombW9ubW9yrr917JXoKhkDCC3uDHb99dgrfmlXzSuYJCR6OvAXAWM58AYCCAkVaKwN8AeJSZjwSwHcC1VvlrAWy3tj9qlSt5jIBLYeyvBh0OWBnJDLnBV9BbCcD3WF8rrT8GcBaAl6ztTyGVNxYARlnfYf1+NpVwvr3SvbJg2PLdiHmDDqbb5BYtGz0RlRPRbACbAYwD8AWAHcxcbxVZC6C79bk7gDUAYP2+E0DHOCttKFyCKPR9fjYWN/57RnKVMRQsJaz7FSRagp6ZG5h5IIAeAIYCODrqiYnoOiKaTkTTq6urox4u7zR1i4XtbRPE66ahkTF23kac+tAE1Dc0JlU1QwFixHxuCeR1w8w7AHwI4GQA7YjITi7eA8A66/M6AD0BwPq9LYCtkmONZuYhzDykc+fOIauff1Zu2ZvvKhQUYV5463bsx94aY7M1GJJCx+umMxG1sz4fBOArABYhJfAvtopdBeB16/Mb1ndYv0/gEp6h+/vHywEY/3GbsF5zSd2/7Xtr8dRnK80kcYFhLDe5pcK/CLoBeIqIypF6MbzIzG8R0UIAzxPRLwHMAjDGKj8GwDNEVAVgG4BLE6i3ocDIyNFwAjUpOXzri7MxcUk1Tjy8PY7r3jaZkxgMBY6voGfmuQAGSbYvR8pe795+AMAlsdSuiNARVIs27MJj45fhscsGobK8NNeqFZrivH1vLQCgzswBFBRGo88tpSltCpRbX5iNd+ZvxNJNu/NdlcQoMDmfro/x8igszIry3GIEfUz8d8Za3zKlLGxsgRrWFl5oLwiDP/trG7C8eo9/QQCbdx1IuDYGL4ygN8SKEdhNh5v+MxNn/f4j1Nb7m8WGPjje8b0Q8hb0uuttPDh2Ub6rkROMoM8DBdDGE6PQglXZ97p0x1L5Y1LVFgDhhPZtL86JuzqhGG15zZU6RtDnkFIWNrbJJqyYT9r9sYStZgaDL0bQG+IltB99Mpj1DclTyiPUUsEI+hjZub8u31XIO+E1+lirkYXx8tBnzbZ9GP3xF9rlzcu08DGCPkaWbPR2myxl80F0rxsjLAqF746ZggfHLsaWPTVa5QtsWsYgwQh6Q6zsrQ0XsyYpjd4+7uKNu5I5QQmytyYVlFZ3ktWElyh8jKDPA6XYL8Rrslejht0/Tuzj3vHSXCzaYIS9HsGGnnUNJdigSwwj6A2xEybcQC5MNxt3mkU7gfB5JLbGP/gX47Cvtt67cI6o2rwnPSIxZDCCPkb8hrClbKOPSi7svGYeIF5ETX7HvsJwRBjxyEe4YswU33JNzdxU9IL+lZlr0euut7FjX3BzgR+PT/wCn32xJfbjliZCxwnxQmtqHa/UKISVrjYzV+/IdxUKjqIX9E9+thIAsGrrvtiP/Zt3F+M7//DXDmz8YtnMX5eyERvNMpsCkhNNHrsZB3kkxfb8iq2+USl6QW9TTM+tqTWyfCK+e8191yOMhdHc28Km6AV9MZq91+/Yn+8qxE7Ujp6LoX+pCKPGRsbPX5tfUC6jZ/1+Yr6rEIgSaQra6KQS7ElEHxLRQiJaQEQ3W9vvJ6J1RDTb+jtf2OduIqoioiVEdG6SF5ALdh+oi9WGfMO/Z8Z2rEIkzCrUpITw5t16i36KifU79+OZyatwzb+m5bsqaeoLYNVUkD7a1OaEdDT6egC3M/MxAIYB+CERHWP99igzD7T+xgKA9dulAI4FMBLAX600hImS5IMbcP/7+NenKxM7viE5DataEPSl0rVzldcgaJcqJOH55pz1+a5CQeEr6Jl5AzPPtD7vRioxeHePXUYBeJ6Za5h5BYAqSFIOxkaOGv24hZt8yxRSQ881Ua+8kLw2mjqZydhgzyTfj1A8//z1O73LCp8veOyTZCpUQASy0RNRL6Tyx9quKDcR0VwieoKI2lvbugNYI+y2Ft4vhlhIuo0ZTxl9wrx7cyEkmvKLOAhhA8Dl+2Ud9uwL1hfOXEdSaAt6IjoYwMsAbmHmXQAeB9AHwEAAGwD8PsiJieg6IppORNOrq6uD7Oo8Tug946eUUwUGIVx/N0K42Mn3ExRf5AvWeQvvpvbO1xL0RFSJlJD/NzO/AgDMvImZG5i5EcA/kDHPrAPQU9i9h7XNATOPZuYhzDykc+fOUa4hJzS1hhEU8f6EGf3kZmVsaVFo11NIfWRS1RZ8tDS8AimDmQsug5ouOl43BGAMgEXM/IiwvZtQ7OsA5luf3wBwKRE1J6LeAPoCmBpfleUk3ciK8/HmiRA3Kzemm+TPkQvscWPibT7g8QvNdHPVE2qxE0YZ+d37S3DEz8Zq5cgtNHQ0+lMBXAHgLJcr5W+JaB4RzQVwJoBbAYCZFwB4EcBCAO8C+CEzh4tdq0EhWUvWbo9/dW4xYucSDUJu5kBKQ9In2eZfmLYaG3elgr8V290K8p5xl5231nvyFgCe/mwVAOBAfWLiLDF0vG4mMTMx8/GiKyUzX8HMA6ztX2PmDcI+v2LmPszcj5nfSfYSCoc/fLAs31XIG6KgDpP4uTEnSlIBaQUFyk9fnhd63/xr9OHPf+GfJ8VYk8Kj6FfGZoi3kWV5aGgcfvW2pqvRj/xDMBc19/3NhUZfSKO/UqRUTGN+HH//+3hrbnH56Re9oE+q7ybdaA/UFd/wL0lyISRKTc4XmstvvmsTZiQZltdmGUFfEriHoYXWqYqdrAFTLgR9iaj0uUp0HnTdQb5NN2/P3eBfyCJUVR23vbjkQckI+rjbmPtwTWVYmi/MizQ4heZ1U4h9ROUOWbV5T9a2nfsLI3lKEhS9oE9KS0taOynETpFLcvUiFZtHaejzBUwBtukXpq+RbpdNvl42enLS1ckbRS/okyLEXKwhAG6zQFIv1lJ8oRbq6CffphsZGwLkCV7okzy+mBWFkhH0cTexLBt9xEbsXmTR/753MWPVtkjHLCWSEhFlokZfzD1VwG6KhSZWVfXJZ4yhhtz47RY8RS/oi8Xr5n+emZ617fGJy+M9SRGRO9MNCZ+TOUeuKTQBb6MS6PlU9BsSkvMFOHjxpOgFfVJke91E48Ml8cbdKHRenL4GqwPk8Q2i9T356Qr0uuttrbgjpRixslCuacjh7R3fVY8jnyad+qQkfZFRMoI+7rbkbrRJtNVS0TBl3PnSXHzj8U+Vv0eZA/nV2EUAgDqNYfmpR3ZKf86VW2KuiLtNzli1PVD5di0rHd9Vcwf5fC01JDX3k8hRk6PoBX1SwjIXWlNpiZ1stuyp1S6re7unrdyGugb9Z3N4x5baZYuFpJqmexFf4PMUoEYfJ7sO1Oe7CqEpekGfFMbrJjpeL2G39qf7Yh3zyQphH//yjjIJvllr6xtx24uzcxrYbsueePPhVpQ5b1BQ7x6V6aZE5HxRUzKCPm4NPEsLSaC17q0tXg0hbnTDfIvPRUdTzJGcx6Sqarwycx1+/tp8/8IRSUpwVpQ7xYHfebKVIf/J2BH9u4SpWmiSulcTFm9O5sAJUfSCPim7ay7yC3xatTX5kxQoukLCjfhcdJ6ReJ5SCYFQKH702S7I/uX6dD44ySoZFBS9oE+KLNNCnurRZNC8wRxQo8/Vk8uleSKpc2VHFPUp7/queh6OraXxri06SkbQx932jV0xt+iOoEQvCj33ysxnI2O8yV7b4H1/N+xwrjrV0ejFEfj2vfqT9flmwuJN+a5CJHRSCfYkog+JaCERLSCim63tHYhoHBEts/63t7YTET1GRFVENJeIBid6BQn13lLxFChU8mG6KRWSuqQgDgj7axuwZNNux7bbFWGCneazzOcHLTfZYuCaJ7MXPBYTOhp9PYDbmfkYAMMA/JCIjgFwF4DxzNwXwHjrOwCch1Se2L4ArgPweOy1llCMfvSGDLr3N6jpRnyB5OIR5mIeICnXX/f9/NBjwrFesoZh6kp5SA+xvqJjT1I+7qpzN2V0UgluYOaZ1ufdABYB6A5gFICnrGJPAbjI+jwKwNOcYjKAdq5E4rGSXAgEt73SNJigeD0b9/1sZMaemnrfjhnY60YosibBDGA5tdEndFz3/fzl22qNO0gdxMOefETpLmArZALZ6ImoF4BBAKYA6Crkid0IoKv1uTsAMTboWmtbUWEUgegE0W437jyA4/73PfxT8JOX0SAMtbT86IXP9742H5t26UczLFSSm4xNpqz4Ajmuext0bNUMgFO7TwrTjVNoC3oiOhjAywBuYWZHPE9OqWGB7ikRXUdE04loenV19DgwcWvcuq5jhnC47+caa6HRuws2eu7ntNEH0+gBYPu+ZCYAc+m52ZCQ72+gNh5I0Gc+E1F61xLxdi0KtAQ9EVUiJeT/zcyvWJs32SYZ679t0FsHoKewew9rmwNmHs3MQ5h5SOfOncPWP7HGYmz0uUVXdjlt9Brls1bgBqmVPrlsH3UJBeoKoiwFcVYQj0uUeYZlMXbenfvk2aGSeikWGzpeNwRgDIBFzPyI8NMbAK6yPl8F4HVh+5WW980wADsFE0/RYCZxkiXblU9vP7Hf1ugkWM/xY8yFkpqUoJfJRFU/eG12lu6m5IvNe9OfxfujI+c37TqgFOIiVdW7pdvjDhNRrOho9KcCuALAWUQ02/o7H8BDAL5CRMsAjLC+A8BYAMsBVAH4B4Ab46+2hKS9buI9vMGF7otV1NDO+v1H/sd1fX9nXtHpHFkECeoWBNkzUGnEfxy/TPu4f/hgafqzOG9TU+f/wjrpwfEY9uvxvuVUo4OKspJZKhSJCr8CzDwJakXlbEl5BvDDiPXKO1leN5qCqLGRUZaLWaYix30/11sp3/zuXNCRlrv8YxOqcNs5/QIdo9CQuTbGgezONjBLhUSQFp41erP+vzJrHR759kDf/fdrjNxUgj7JvsjMRRNWw7zuFKzdsd+3jGxlZi58g0uRN+es1yoX1OSaKxNtTp96jkIgAMC78+WT44EEnGt1chJdRCXokzTBPvDmwsSOHTdFL+htX9y4H+fV/5rmW0Y2IVWf0LC6GPH2ow9H0BXLuX4auVDwxJfXTf+ZiYlL4omkKLu1T322MvJxvfIvxzVZqrrvST7/J2O4N7mi6AV9rpB1Apn2rpP1yBBeqwsqF3I9qZ6L04leLG/N3YDvaSglOsjurUpzD2u6aV7hFDlxTSznQ6MvJoygj4CsDZl2lSxBOu62vbV4a25xTL6u2LIXOzR9/KMowQfqGjySeGdvV5UNMnKxNfrT+nZCRXmZQ/DXe1zM/tqMbf5vH33heQ7VnKvpjymKXtDbDS7IA922txb/nb7Gv6CAzMdYNuxMcpl9oRImAfPbIQVwENPNDc/OkG5PUssLaro5UNeAZyevwpm/m4jz/viJ1j5h679m2z4c/fN38dxUedtPLrRC6n96dCCcSNV29tXWo/9976a/P/TOYs9zqDV6efkimUONjZIR9EH48XOzcMdLc7Fiy17/wh7IhM5X/zQp0jELmWc+X4k7X8qOULhd4eesejZVm/fgZ6/OC1WHIDZdVbiD93xW34bBFr4fLNqs5fdt89A7i3GvlZVqw0698Axh31PLrfb+znz5S1b2Atlf16h4seh3vMwCKeu74zf5PkHt3ypBr1IMmpicL35BHwZ7EYU4NAyDyhy/MuILpFD5+esL8OL0tVnbg75s93mkUPQ7VqB4LIrt63YkG+/mzpfl4XplhAnJkFSAPdm9XbRhF/720fKs7UGe+dy1OwEA5QF2ChrwTHVoszA2RckI+iCNv6I81SqC+CPLOoGtLXz5qM6OhnbG7yZqH7cUyJV2NHXFtrRWGoWkJ+i279XX6MNUJWz1/a5b9evb87JdX8M8c9t0I9ZDdc5mFcFEk6o+6jmGpqXTF72gt9/8V4yZqr2PvVrOayLIjWoxCZBKeHzfV4/RPlapEbTThA1P+/2ngnmX6GQ8SoKkF2NG1VJVz0uZCjCm22XnHneabuQHryzPrqPXi0p1Tao9mpaYLwFBHwa7EdXV62v0VZv3ZG2zOwYRNenZfZWLXNzxxuNa+h/3cH7n/jrHnEPSbSG5xCOJHDZNWVqjz2xTCmKJ4Paqn6qlTVi8GTX10Uy0pUCTFPT2hN6DPjP5bqo2OwMn2ZafciH0alPkqif0R1NRkC2F9+rEykU0MT+sP09Yhi17Mrb2KSvkmZbiIimBrHa7jKcOsglTpVeMtB7hLnxsCcQ3ikrRC/owprYaS5Ofs2ZHoP227nFOnDUK3gRNeWHG4o3yyIE69Gh/UKRze3m45Mp0k/sJP70Trt66D/OsiVAdAoUeDnEP7bkxnfk02Ushzvt8XPe28R2sCPANalaKVIQMdFTu2i8t6MsosYQWhcBPX5qLjQllZjp/QDeM/jjbq0OXMJ1fFqMoTk7p0zHR4+tW/8sPfwgAWPnQBbj5+Vl4f8Emz/Kq5RCy06mq4BXo6/rT+1hlxOPoL8gK+4KW7XZEp1bYvOtAOpheqdMkBb1bYOvibsC26aaMCNNWbo9arZxwoK4BM1dvxyl9OvkXtngh4OIyP9yJKESC2vW9PKdylefXLUh6tm+Z0/Pp8Pps/6BxcWj0+2ob0Kq5XKy0bFae2tdxIPnxg3bRME+6KUWZLXrTjahJ6w4nw8aodreLj5ZuTp9X5iVQiPzs1Xn4zj+mRF4sFhdRswwN/82H0onyqPS6623cE3JRV9IvGK91CDoEdUWUoRpV/PZd9byXbLGb6oyff7E1a1ucSUQYTWt1bNEL+vnrMulrdYe0YR9w84pyx/efv74AQOpl06V1i3AHzTFLN6Xs6XsOhBcW2oJGcZ9FrT0OpWrBerkdOqop/t9TVkc7gAZhqnjHS3MDld+5X8+vP4hFq3ULuda+da/ahGmPGAb2bOd57BmrtuM1yQhEJvxtwswZuEePI/p3DXyMYkEnleATRLSZiOYL2+4nonWujFP2b3cTURURLSGic5OquAzdoWdYQa9eTk3pYakfN5/dF93bRZuAzDfH3Pee47s95/G9U3o5tuvc5rhdMHWIW9/OlYkoLCc88L5WObUfffb2bw3pKSmZcnRwz4Ec2jalBPXskDJpPX75YOHY2cd46J1F0mPrmlxvGdHXt0x9IzuO179bm5LW8HU0+icBjJRsf5SZB1p/YwGAiI4BcCmAY619/kpEehIwBnQFfdi5OFUEPSJv4TFb8O6pLCcce2ibcBWIgSScg6J4scQhJJN0eHpt1jp8Ue1tGioVh6sg/UIldMct3JQ14hh2REf0aH9QekR8sDAaCPL8vQS9eJSvD+ru+E0mwGvqGhwhk1MJUUrkQUrwFfTM/DEAXcfgUQCeZ+YaZl6BVN7YoRHqFwjd5zQ1pJ+zKuRtasGU+uQq00I+iVN7yUQnDL7vIW1zP7oJ0p9veWE2znn04+Qq4+KO/87Bdg/zR5IEEXReZV+e6YyH5LaHi/MyssOoRnnNyvUszTqjxNqGRjSvKMO/vvclvPWj4SllrXTlfCQb/U1ENNcy7bS3tnUHILporLW2ZUFE1xHRdCKaXl1dHaEaGZJe2q7CLz1alldGh2S9MoqJrC6ZkwxNwdpJ0CxIUZrhf2esxSPjlvoXFAj6glUGAAsSEiTgNYrC1zcvsELL7xGjN1NNXSOaV5TjzKO74LjubX1H5cVOWEH/OIA+AAYC2ADg90EPwMyjmXkIMw/p3LlzyGo4iSstWVD8tAH3T3eO7IeubZqjQ6tmidYr17g1qRpFiAkv98owqASD6pkUeofO15J9VfeJqj+5tX+HRh/gOF4vaPEnnTZVU9/gCJxG8B6Vx8HM1dtD5W6Ig1CCnpk3MXMDMzcC+Acy5pl1AMRZmh7WtpwQVM6femQ8C1sI+rbGXp1aoXlFOXq2b4lte2tRGyDeThwk2ZaLZjKrwMfoqhekirhu+6uz9LvqDk1PHiDbdCN+DmQu0i7p2k+yo226EeuUZKtYsH4nvvHXz/Dwe0sSPIuaUIKeiLoJX78OwPbIeQPApUTUnIh6A+gLIDeBUBB8MuWgynjWixGR90tGqNdXjz8UADB9VWqB1eKNu6S7lDJxe9oEltsF8kbaU1OPN+dkuxHma2Q6b53+XNKYSSsCHVu84+Rjo1fhbXLL/Nai0un/IbudNXWNaF7pnozVr0tQ7PApC9bnp7/ruFc+B+BzAP2IaC0RXQvgt0Q0j4jmAjgTwK0AwMwLALwIYCGAdwH8kJlzNg6Nq38EfWEQhZ8fiJr8pJAIIz5fmuFKZBLiNga99S0qvZt90OfvLq+794eLNwc6T7Eiu50PX3y8srxKEdjgkTDmrxMzHnFuH3/Z86ypb3RO7iYcmNA2V+VrHlHH6+YyZu7GzJXM3IOZxzDzFcw8gJmPZ+avMfMGofyvmLkPM/dj5neSrb6TuG5i0BcGAaHHfY9+EGzirdC5dcRRju9+QnPzruirHYPe+oMVS/TTx5McsNddb2PDzv0Bz+RNYRuQMizZFD5oHWCbbpzCO0zij3teU69UfmWm2uwkkws19Q2OBZBJuVc+Mm4pbntxdjpHQb5Ga0W/MlYkuKCXlw98nAjaQPXu+JZ15xsiYEiv9o5t+WrYXvi56amev26oBd3mky+/7VwbrpjZI+xCkOP4lxl8WLssy5ysCdbWu0w3Cd2Ux8Yvwysz16XTKOZreqi0BH3AeU2lV0YIjd7TI8Bj39ocz8Lnup35yXl3B5u6chveiSl+uDK+us9+Qd9NhfcqK0CygtelkDkxqBwbdEI5XH1q76xtMmXDbbpJ2kZvL/ZqKFTTTTERn+lG7zg9O6QW+/Q7pHWEPJ7h9itE5FmBvDuyTJN6bba398dd5x2tVR9VCFq/5xt0te7M1fFGLi3GfKZez0R2N+1LjLv9L9qQPdk5bWX2Askal0a/bPMeTKragsnLs+Pp6MYK8sKOlGlMNzGwdvspYYHEAAAgAElEQVR+/N+bC7Vv5t7aeuw6kP0QdQX9JSemPEkH9mznKRqCLKZKmiRFiOzYfvdSNvHm53LatU1zx3cdE8iYq4bgtL6drDp5lw36TMTAevmgEKxjV558uPpHzm4bXu+yc489JHQ9GEibSWzcIZobGhkNjYxm5Rkb/W4ryJ8snPPFj38Wuj429mRsEM+mOCkpQX/L87PwxKcrMEuhYe3YV+vI7Tl5+TYcf392wKc/TajSOp/YnLwEmtdv63bEO8GXD+x+1bl186zfZC9dv+iV01Zu904EHeJ1dXb/rnj02wNTX3wk+dwAWZlkvDFnndYq01IazfmFmw6SvLvNQZWh60EAKsrL8N4tX1aWsdtkhSS0+GZJgp1lHnMzOzQTDtntvKGRc752BigxQV9rJY9W9Z/fv78U/9EIPfv4RHnwMhV+Xjd+ff6jpfGEgNAhCdnyjUE9AMjto37zJkSEUQMPdWzbU1Of7Xbp2Mf5/Z35G7VS5mVc3LzLfevvn/sey4u6Bvasf76RCd3VW/cldr6Pl1ZnBYaz/co3xZy5zL60foe0VpbxUrzGB3R5/fHzs/XqJSgn+XCxLClB75eYIO6JEHZ89lqe7X3eXCXXFonbDNy93UHS6IL+phvgzpHZ9l0vLcqtPU5YvBkX/nmSr7C39wrb0YKMJKo1kmSEidy5W2JqjIOo7cFLo99dU581enlhWiok1lOfrfQ99nnHZUw5ve56G5t3q18OQRLZRE16AwAbNEfkB/IU1sKmpAS9Tc7t3kSe58zXIgk3k5ZtkU5WRSWVJ1T+203PzcwuLwo4Utj2PdRu1bn8tMOyPLu4uQlTj+uenhF/RRBd0Afdv8LyeKkPYeJ64M2F6nponDud6zmWOEt65Cv0gU1RC/ogfsgvTl+DWat3+BcMcE7x9N42+uxt7o6RC5/q746ZkshxUwtiUp+H9u7g+O3TKnVWICDVMeWJoNX7qDQxX2FD9rGTv9dJPE9mxuQV3vczLOJcyvwH9PMF2fGigmrHdrIanSBfI45xZn7ynP/QqEeUsNo2x/doax1L7zmLodHzoWgUuaDXL3vnS3Nj0Wbl8bO96yJ1MXRtKsSFRbqkFsSkek1leRnO6KcfjVQ1SefVgcL2z1zmgn70g2WxH/Opz1YmJiREzdpv5TAAtG5egatP7YVnrz0JK359fuhnouNKevGJPRzfve6BzjPOaPThaj31Z2dn9g3xPPKRkayoBX2uFxsBTgGkG25Xp3PmeiFFnIHFGM4O5ndkUaiQoi6egl5xAr9+m8t4Izov7qDVeFXi+mczP6LbXuCY+0g9NyL7L9j57DUoYUJ16z4/0bd/4pLMJCunNfrgfeCQNi3QpU2LdHsP05KMRh8Q8eGJBB02H6jTnyhRLf74v1HHKfeRDTXdIZKDrurNBY2NLHU3yyrHwTrNdU9Pd3yXm268BL3CdOPzirF3W+8RHCuXBO3vB3kEY/vd+/o2YNldqm/Qr83emnrsqalHbUOm3xARerTXzxZ2+zn9AKTSDOowtFfGJOjVNkQt/STBjPi9f01Lf+a0Rq9XV5GHL0kFY6MISoPxugmISqEPehtPenC8dlmHRi+cqGubFjjx8PaSPeTa+ugrhmSVWbRhF96dH8/y/zj44/hlGKpxb9yxTNyCeKvLA2XLnozvsWr4HMZG74e935OfrcQZD38Y6hhxEjhKqseLLKoHSb2PpiHW1c6d/Oxkf1dlFXYseD+h99aPhgNIhcaw8ZrAdSYg8W5bYe5Yl9YtrPNw6GN8Ub03xF7RKGpB79c4dQmyxFlqo7calLgi70NhtCFrl61cdtCGRsZ5f/wE1z+b7aWSLyZq+veLk7FAduO//b9zlPuSwuvGq/+rOtd+n5GZWMeVCr/xhXmKFy4ii1HvR9T5Bz/vF9HTpS6A9q/C7jP2ilQHwuGP694262cvM5P44lAHUrM0+gg3LTOhG/wY//xkeejzhqWoBb2uXTHO9F0nPPB+ejGM++xlwt2s2pTxA0+//T3aRJB8nYVGyr1SfXH7anxMY5Jd3dquuEaiTNFqb/x35iUpu5868xLnP/aJb5lCJGp8HL++9KSGv3uQAYotY3/xltpVUkWdR38Wq6C6JfZLfue+4GsS7Hk5+zxh7no+YhmVpKB3N7iHA9gv/aipb8R9r8+X/iYuGBInam0twx2DQyTnk7ExtjVmdwah6Md0D+nFEMEEwvkDvOOhyDTUXHrdAP6mmTifeNRrc8dz795ObW+P4/lGMTV5vZTYodHLz/H4xFSIk3fmbwxdh8yMbvhD5BKdDFNPENFmIpovbOtAROOIaJn1v721nYjoMSKqIqK5RDQ4ycrravQLYg46lW5Lro7sZ2+OU6M/UNeA2WvCrwuI+l5xryfw6rh+7mSyDuk5CCPgT5d5Ny2Z7TeqJhW7W1yMhwsiOGVFn5vqtLdPvOOMiDXyqUOEfb3MTA7TjeIk9u6qkaEXvTq2chwjlEYfYp+o6FzqkwBGurbdBWA8M/cFMN76DgDnIZUnti+A6wA8Hk815eisqksCcfgmNiZZCAAg0/i8BE1Qjf5Xby/CRX/5VDsZhhstoeUVY1/46d0FG7Fss5iFKFhTlt0WtzYsFikjUt5rm217s4NNRdV6g74cdec44iCO5fwilT7JWaLi+dL1uRRvjd7/3FH86O18tHb/KZaQ0jqpBD8G4A7oPArAU9bnpwBcJGx/mlNMBtDOlUg8VuJ0UwoyISu2M/Exq0wzdjXdv4/o3yX9ea+fHdvFWCs5x50vqSc6k8R95x33JGvVr/o4SS2Y+lgiZKN2yqDt7WrBpS9xAlya7DLci5Jk2LHag95FIuDHZx3p2BblpevlCqpjo4/iR29jh6YOI4Py8W4I+9ruKuSJ3QjAXqPcHcAaodxaa1sWRHQdEU0nounV1eE0H9UDd2urOtrr+iDhgq3DuZ+xahbfNsu4f+7T5eD05ysDhiewvRG6edhSvYjTdOMmsCCQbIvqXmlrXnEiu+QoqSC92mXQULZBtFPZWXV84D9YuAlAMEHFzKk5HNdOnqY+n8bp5W0XRKOPQ94uD+EqWaimG0849VQCiw1mHs3MQ5h5SOfO+kvmRZRDONdmnYcfZMGIc0Vs5rGNVCRMOMoKmXrfhccoj6nKhqSiT+fUS2JQz3aB9guC1x0J8sC9ypLi90lVW5T7nNzHf5GNfX8AYOo9Z/uW10EWNC1KSOOfvqxOdn3p6GDHDaIhywSpzhxRuRW/PciqavtUbsHu9bLwM8l6avSKdS7yOnmepqQIK+g32SYZ67/tNL4OQE+hXA9rWyIc0raFVjmd4VWQIZhd1K2RfeXYrpLSmcUhQ3o5A35FmYyLaiPUuVyvBBxBRgRi57vh2ezoi7J7v21vLcYv2iQ9np99HnA+G3uRS1TueiVbMK/Ykszil5kBA/BFtdHrzBF5eY0B8heIfVz3IxPbrXs/P6XLq67iL6piUWPdFCNhBf0bAK6yPl8F4HVh+5WW980wADsFE0/s2JESj+jcyrOczpxtEEGvWpThp0HE2ayCHvPFaWsc36N6kNxjZeqSdW6v/uN2aSOVSg9gcwiziD3Ky0eQuHzKDaKUJ1bYNSM6t0vnBZt9XEuolrlNN5nP7mdl+8lP/MkZ0mN6vQjEkYmqT6tGGbmiIP3oieg5AJ8D6EdEa4noWgAPAfgKES0DMML6DgBjASwHUAXgHwBuTKTWFl3btMAvRh2LJ7831LE9a6JQoxXbjUInsYPCu9LB3z7KrH6Le4Z+6opt6QUsuod8ZVa8GY/+O2MtDtQ1SO+Be5un6YbUv4sapO69syOUJiXn45ybiJMyIhz983dx2T8m+5aVXYFOH7EFYzAbvXNfG/F5uk019vcubbJTUwLeC6bEQ6muKOMFl9n26LdPUB7T5pA28YwM84GO181lzNyNmSuZuQczj2Hmrcx8NjP3ZeYRzLzNKsvM/ENm7sPMA5h5ut/xo3LFyb18TTg6w1K7geypkSzJduGMpyH+kPkouvfFbRMU7cK6h3TbVX/68jws27RbUVoP1W099chOgY6h0rzCLFFPm9USWoCWz3DS3pmVUv+nrZTnSxaR3RqdEa2fnV36AlGYbsTvb7iictqjkgqFo7tXfxdHqqo2IHv5fH2Qv9dRq+bxTPC/Oisxa7aSol4Za+OnYei4TmY8YzIHO6xDS8993M2odQt5HO/M4orokv6deU5L2A5Nt1D3PVq0YZcjZEAYWGEAuvLkw/HwxcdnynnIkF4dWyl/rwgh6O2XelLy2EtpkMVliROvYFhRvW50LD62a73qTBskDgWNEqHq/r7bpVzZsXQqJcm7AaDzwXJNH3C2NVUbkGn0OiS9tiBJirfmAn7PS8cFyu7AosZ2+lH+3kCi8FZpoDqxbnS5wSWc/6CZ4CIJsyCzykZPaHtQZaacxzF+cm4/5e9hNPrGtKBPRtJ7Hfbpa4biheuGJXJeNyP6d3XYzONaI6Cyi4vnCHJn7f7kna/BbbppRHkZKa/pk6otaZ9+72PJa+o3GXvz87Ok268Z3lu6PYqLba4oDUHvemBh+ri9jygg7rmgv9Y+vse2/ud1sk7yOowqCuNwv6wsJ7RvWSn9zWmj1zuePTJLStB7mW7atWyGkzTjq0eFCGgjjCDdIQy8kLpXMqNdy0r06qR2bHBPxuo8Evtc7n29RiD1DZw1mvuyoHTV1jfi0tHyuQjx8ag1+tR/VRVeVyR4OUXh1jvqz5PkByogSkPQu76H8ShJa4LCELZFZTmO6nqwYg/FySVkNPpokv6zL9S+5fmAWX2nHenovCYwidCymdzk9UV1JrzDE5NWZP3+5k3Ds7bZgjipRC5BQ1U8Om5pbOf+2gmHpj8T4vXeaGhkX/dJ+9cgt0Btusl8dh/v5ZnrUONaMOZnxuvSOmXOuWVEX+Vx09vTdfC/f4s3ZuJkqe530DUw+aA0BL3r/h+oC97L0255rtbh1ah1Xyj2wpio3fK7/wyf3HurJPZLVBjq+6PSftx43ZNHBCEpizQ4oIckVnnCppugwef+OD6+3LFiDgMi4I+XDlSW9UotKLs3jexvKgsyDzDFMq2oJ2MzG9q6RnRb9mSbQmSunV8TNOmDmpVj1MBD0VGw36vdK+V1kiGuUA5qSZy20h05JoOO00eclIigdz6BHzzt7exz5cmHZ22z24R7aC5NjCCeW6N+NhWuyaWgoijKBGMcidHd+MWwGXRYatWun3tlEnXKh+kmCGGC0TmTuxBO66ueQ5q6Qi1kZKOd56au9rU1B3lW37ZMK6qAfuJXnfALsolZ94K+rJG9z2SszotLLBPUvfJuyQI7m8lfyOcYkqIkBH1Q7r0gOxSBrUW47Zd7a9WC/u8fLc8aYnqhcheLSlhXwsguiOw9qtGRC1EXrTx9jXMNhS2IE5LzseUNCGPXdSRg97ltbqUCAFo2S7kHhn0J2s8qyLoQ+6Xi5UevU51yn74jX8+hmIxtzK6D+rzyCe9vDdFxx5SbJIHc541tkoK+WUX2Zd/x0lwAwByXlhDleezY5zSXqFYW3nhGn/AngXeogiRhsOf98RPi5x7bFV0tLem+r6rjAHnh7kxXPjEVn1VtUXakv14eLUWCju1f5921tzZYtFLA5eFlnURlThDv/U9HHo0Jt5+eTiYye82OUCOKMOtA0kl3PCTN5f+cgjk+uRX8bPSNnJ3lrH2rZtKyFxyfCqh7g0a/U/XZ317sv8BK4R0KwAj60Pj5vNvcfHZqsuZQxaKLn7jym0YZqu/a7xwNuBvriP6p2DjD++ovMJKRq0Zz4xl90FHoPH6ntfudqtzfhQTpKtc1N4MP8w/i9tKMtUoz11lHd5H/oImORp/U0vpnJq/KfCHvc4kCqqKMcIQQ5K2mvhEjHvko8PltQfqXD7+Q/v7S9SenhaiNTi4GABjtk0e108FyoZ0+TyNnCeX+3dpIy360JBUtV0dmRFnk6BUyIsbsplqUjKC//nQ9rbidNfHT3ccuaE90RRGi7rbtHk4P7d0BKx+6AMf3cAqvoCYVv3kEFbpnOfqQ1lj2q/Nwx7n9cMyhmc6zeKPeytqa+gYsWB/PqKOry06qkh+qF3RUGawXKiDaOXSwT6G6Hlkdgrbk//nyEWgmqOJZgclc5Yf06oBzXRFcdePK2Pd1syRCKADcfk4/XH1qL+X+DSz3GjraihwrMtWaJNXJ+GabjERvHl28rtlo9CHR7Vy22aZ5hfdyZvttH+V5uL0YVDZ6d91lK3mvemKq8jy/izEnroxRA7ujsrwsSyv7eFm11v1ZumkPLnhskucSfgB49cZT8LfveptWsmy9inL2y/KyoYd57q9Cpe3pdNDsdR3xd+pM3Bn59YhmnrAvt7vP749Lh2aC0erYtJu5lJmG9Ipz7/3s+7pq2z7p7y0qy/G/Fx6r3L+hUe415JVQxd0Wfnx2Rpjf+uJsR716e6wvUOGl0RtBHxJ3G3xzjnzRg62h+L2h7YcU5YE88/kqx3cdeyoAjF+0OavMRx5p6cLa6L36niicRI8H8X40sioIgn0M53e/LFqDDmuPkcd1Q+fW6iXut51zlOcxgJTmaivebi1QV9D//YoTpdt1THnu57xaIbz8mLFKHbfGvgylLIlpVCHeL52Y8mKYAGYWbPTeFbJNGWHCXgCpthg0QoH7TOK57UVT6SixId6WXtdcFyD/RRyUjKB385oicFAny8/2oGbZGr3Yie1GHUXQ/+0jpy1T1VjcHShXTcDrPKI8EzuA6P3gd2vc9068Sq9h+H++fxIAYNgRHbJ+yzbdyO/pgbrUS8UrmJYXqjgrYYJ/XfincCsnv/n4Z4HPZSNm2LrkxJRWHmZkIR5e596Jgr6RxVWo2Tv/5wcnpT/bUWPbWKEzvndKL+06bt1Tg217a7F+R/aI0evF7rWIyya92NGnDn/4INjCuFYS+ZMkJSvoZW6PbVpU4Ix+Kd9jWZvv87Ox6c8ZjT5aPXTCHrsbWNAO2SyBYEvvL8gsUBI7qdhA7TRxKrzu3UCPzFhHWikWT+qdvejKLYD7dc22wTIzbrcm1bP9t3U1M3k5nUk09567Qs6heJHxupHXs9JqVG/eNDxrQVIQZJ4+st9sKlyjP6/FSe1bZiZYp6zYhu17a9PtaZDGpLuNPdqdsDh7JOz5uN1KgKSS9upsv5GgLOaUl+t1GK+rKJSMoHcLHFujE/nWkJ7aHd0W9H/+ziDPcjJBIzJdI2xsmIQOIjpaZldJbO/l1XuzomHazBcmT8XqiXVtZO/Y4O4Xlnjr/RZbEcmvy/1Sk43MRMJ6wIijmOd+kAlUpmO6kbWxuMMb20HjlJPR1r1rXhmtizuapsatbObQ6FkZAkG2beveGtjjTN3nxszYL+nrqnM4f3N+l03mXv9sKoig7DD3umJhLXWF/fYS9G7X66SJ1AqIaCURzSOi2UQ03drWgYjGEdEy63/7eKoajAP12Q+/3Mux1YXdQL56/KH4rRByV6TtQZVZ5oUTD3debhjBEFQk6Lj8qeJtu6Nh2ojVPkWIL+8U9IzfvLtYec4osq2cyHHvTj2yI048vH1gW6nXO/TvLtOa6FEjXqeYo1ZrMlayzWs5fBjuHNkPAPDg1wdIf89MgmZqM+IYeapLLxxarvvSJRdaUe407XlNxrofZU19o2/AsQ9u+7Lj+7Bfj/dRGrx+c/7opXDJfvr+aUc4vq/bsd/x3SvBuyz/cJLEodGfycwDmdl2ir4LwHhm7gtgvPU9cdzPer9kaHSO0NCPcfnYfnOwUxDqaNmNjeyZIg0IuZIy4C46p/CKfSJDFGhiou2LBnV3nHfhenVoBa+JWr8XYFkZYdGGXdi86wCYGZ9WbcXyar1FPuKRvWKI//od50tKzHSk2i+sZr43xtgmyx88Px0IThVTSDYJeue5R0vLembNcsh5ZzlZFxFHQg2NmclYmWbtHg3e8+p8X3dM0dwDAJt21eB/31jgUX994e2l/S/XyQ3suo0ne0Qydb8UkiYJ080oAE9Zn58CcFEC5/DFDmwmammDD8to22VlhMtPyrjeuRu7jjVF5bsrEiaL050vz8UfNePM6zKpKljky1mr5CsVz+yXWXDEzGnhONSd+Bzeq0jHL5Yn/rYpJ8KHS6px6m8mYO32VKfYvk8vyYqILBSAiKgQiC831Yve/eIebo123rtF0DQlu3ppd7oQASP6d3EoFypBZstQsX2Wl1F6HYmI17tLFH5rtu1X/iaeI3Nc9hTc7vYxe82OzAIrRX1kz8Xr5evVj91zDF5ldZIXuRHNZg9+fQD+dNkg/OHbqfU5OibdOIkq6BnA+0Q0g4ius7Z1FRKCbwQQfLwYpiKuZ11vtSKxY7o7xf1fy/jlTljinMgRG+ZpipWrDZLVeO7Gsy/kpMsfxstn8e84t590exRfbfdiJmZOLyrxolEYmssEyIadTsEgVrGFzzoG2+4axg1NPE+lT4yUUx4an/4sCvqKMsJzPxiGJ6/+kqO8ewRTVkYY2LMd+gkLc2Tyoi4GG/3BzSvQU3MFeDpjmuvyZXXzMkeJ5f/8YZXvsdxzOJnk4NllZaNdP3fGoMlovLK6uU/hNYrXyQ738TKnC7R4X489tA0uPOHQ9Ih48+4a6TxiUkQV9MOZeTCA8wD8kIgcBjROSR9pKyKi64hoOhFNr65W+4iHxc4U7/W2F4fnO1zaovjQu7U9CGOuGgI3jZxtunG3h7iCYNm45wBsbK03DBc85nT/05VJDG8/abcGLjb88wd0cxdXEnQ+Vay+375iHcXrblFZjpP7dMQZ/ZwhEx5+z7k4rbGRszTB1i2yX3qqavTq2BLXaoZ/AGcLHNVxay2VXscEaT+WIySLgvq68jHsE4L8yYSxeL6x8zak27+srDxcsl1eXle/EbQbZ9x7tXMA4P0SUbnbivzr05WO735dX7XWJwkiCXpmXmf93wzgVQBDAWwiom4AYP3P9nlK7TOamYcw85DOnf1T9vnWxfU+sRt6bcigEu4OIksrKEvW4G4OYeW8aj/75TTosHZY8evz09vrFdK5encNvi0kE9dB1w79/oJN6fPKOok7h24q8BRw+UmHhZoY1GWmsNBITGnoh6hhqbx53B0+tVDHue1v381ebKWST9cM751+1gdVeo9yGjn7pSJjyvKtuPe1+QCyBaOXwL1YEpHxooHdHYvHvvevaZljSc4t2ujfnrtBOilsIxtt+dnog3qouT29ZnsET8tazyJ0wuaSQIh+2PsfVFmOPl2yExip+mwShBb0RNSKiFrbnwGcA2A+gDcAXGUVuwrA61ErqYMsjvyyTbvTmn1Q3A+9wjU5x5brmFvAfftLPbPKxYkYKEzstM+KAa8Enpm8ClM8YpPL8PMsOal3yh6/eXdN2kQgW9HojgtT35iy2XqtfJUR1NNml2BPle37sMKL6oE3F/oe2+3bL4uaeOyh8mBaNmKbEPe8/ZyjpIvE0vsh+4UhuzWfLMvMx7jbp+xOeglXMa8AAMwTVmHfLFldLh6jvrERf7XMPbJomcd1z75PnHavlFRUUUcvhgkTog3MuOHZGenvfmHDRZnSrqV3UDUZjZwyty36xUhnxjWLF6atwc4Q805hiKLRdwUwiYjmAJgK4G1mfhfAQwC+QkTLAIywvieOTKA/P22Np583APzvhcc4cm/aeLWngyrL08N8t8b0jcE98BNhmX5cUeoO79gSR3TODK3dV/vKzLXS/QJaPQAAL05f4/m7OLdhayWyIbVbY7GfUdDhd1D8Dt9REQlxgYZn0pePcs7XNDZKvDfKCF88eL5jm2hyeXmmc9W2OBr1sgWnNHr/eyfed5177TcBKtZJ9Fl3KzWAc/K7oZExzZp0XC/xMiEijBp4qGObn3tlUI3+8I6t0vNajcyOUZtfDlzR7PqtIdnX6oc9glUxe80O3GbF1Ema0IKemZcz8wnW37HM/Ctr+1ZmPpuZ+zLzCGaO14FYgczcMGbSCocGIuPqU3vjzICha1tUllmLO4B1O7LjmIgKcX0MyUvrGxqxaus+9GjfMr1q9KYzjwSQSYCg8kgJs2DovtfV7mpAJoEFkJkbkHn1uJ/JBiu3ZvAJNW8O69AyfT+0jue6J3YmIB0f+f21DY6Risx0A0iEiPB1ozBJ3UUI6WAvFFPBjKybIXsx1Avahftey67Q3qZqK6o6yeYixOtetGG3b6hqN7NXp14Mqkl4r6ajmuuwr+vPE6o8Pbfc1ym2X1kOCz+Y/fvfZp+sXnFRMitjO1hx0t22tO/7pBUEgJ+cI/dkUdHIwFtzUo5FL07P1qS7CKtQazTz13532GHK3/7+cSpW98dLq9GmRSVWPnQBvmLZuH86Uu4bbZOE8ixrvLIG+/INpzi+2yked4VwVfPi4zvPxE8EbyQ/06e79s9NXQ1Ab+L8/jcX4v/eyph4wnpV2ZxzTFeHEFTZgu1wEzovbnGxoPuFI45wdx+ow4G6BqzamvIRd6/stAnShMQRxJ6a+vSckkpAuzffb5nPVIlRvMx4oru0iH3uP02okv6eqYvz2FFt6DpzKgkPbtOUjKD/xuDu+Ovlg/Gz8/v7F3Yhy1npFUWvkdnR2d1ccmLPdBzsGskKXRm/vEi+wvHpz1dmeXqIiMmQZbiv4ku95F47K6wFIRN8/NsBfY38BEU8myDpF8PgNy8iE5bMjLp6vY795Gcr058XbtiFT6vC5/8UBRcBuFeRaWvXgXrUNjSig9tWLHkU+2sz99dtuukizI8MuP99HP3zd/HW3JTS8tpseSDAIHMkbrv3D6zVo1cFCFIGeIfWUKGqp7a5x1VMJ/dAS9ekvb0PM+Ppz1f5rv0IExUzDCUj6IkI5w/ohiuGHR5qX5FjD23jOfnip/iVlRHuseJgRBVqfmYUP9xC+dYR8jC/1z6V8qa45kn/EVBUG/t/pqwOVD5oBFFfjV5S/boGTntoyVabukMNjE5LK0UAABG4SURBVP74C9z18lztOj0yLrMuwqtz9+l8MNpL1iTYgq+FRuya/XUZF0j3fOOz3z8Jbuzl+PZqWzdBLG3uMCN2iGav/KkyhvZWT0qrUM4xhGyvOhq9u22+v3CT9r5AbNGkfSkZQW8T1P4rwx0OwY2O4LG1CNtb56vH6/uNJ8nxPdth8S9GZm1fXr1XS4MB5ItfVMgEU9C1BUEdl7yCXAFyu3Yjc9q90R0eAwDOH+DMnPTg2MV4fpr3pLWIaIpQjThseeS1+jMrSbbkUKK50D166dY2e/T6ijU5rAqdq7NYKFPWiW0WU2nVqv56Qg/96JXpcyuqqRvj3l1Kpz+4H6W9ziDpUWtQSk7Qh+UHp2UmcvyGejp2WVvrtY9013netvSkeHxidn7PFgp/bdEk4YVMo/+f04+QlASm3jNCa38vdAV9N0UeYDeyx9vQyBh5XEqYXyu0haB10MFtlcgOv5FdQTtdpFtoyZSOkwQXzSD3uoUqEmiAx6WaY1D1KZVS5dUHH1ckeFe1a78wGDbHuNxif/D0dPTscBAOaaNuV+67b4e60F31mou0k4AR9GnExSpxjArsxvWGtfotiZjxOuxxBdPyurIqSdCwGfdmC2qZIDpYMexvI1slGvD22sLstq94Z5fSTRAvuwlLNu1Om0w6tsqe94hjhbM9X/PEpysc279z0uFoXlGGc6x8q6KQs/exk3m7BaBM0D84NhOsLUhbVrXRIM+rorwMc+8/J3u7oh6nHikPL+I16XzegG648YzsHNHupDR+53Zz7KFtHd/nrN2Jdgc1y3oBiJzqMvPZ0Vx/YuVD8MPY6HOM2CHi8PN2N9QwMeejxjCfvDzYJKHMdi6b7I36ItS5vaIf+hLLG6R7O++E7rrIhMjtL87JBAKTXF/HVsEXzLjpd++7ALIDZPU7pDWW/PK89PWJ9fvLh84RmVs7jXNxpSpiZ9CnLSsf1M3Xr78MV8SfkiGbEP2OwkPnBtcLZN66ndjjkTjmr5c7V0Hb55q4RC+si7HR5xixIQZRvm9XaJnu/ue3Ck/G2u3Bco26TQCXjp4c+Jw6yDph3IqJeI7/eSa1mtEdJM2NO9yBasgtCzWwYsteIaRu9j650rwA57XvdCWocN97Wws/VNNs5YXKxBFUSMvKe2nVsgWLfrpEc5+geCKLN2SH0paNNIGUu/IfLx3o2OYV4M8v8Y0fxr0yx8jyxerQUuFN4B5RB0l6YvPTAF4dADDoF+PSbpIq4lAAowrCIJN7Iu4wFG5+801naIMBPdpKyx2v2G6noktSqOsknNi2NyPc3aMnt8Bs27IS/73+ZPxVEl9HhcqOrhLGQW+HrLzXKPDDn5whOYb3SYPEnpH1Ua/DRwkQ6ObHZ2eHiXDUI0c6fZMR9H5DQdGdS1XWzjfrOK7mcwqT3X7y8mCLinfsq8OZv5voWSaO2Dth0/MFxd2Z/are3mVeUQsu+fZ5AZOzhOGkB8f7lhE9ldz3Wpbo5Uu9Oki1YhWPf1c+mdlFMQKS3Xd3wDqRoO3Dby2IjCCCXhZnxquGn38Rfl2EG1nsInEuKajrcFiajKB3r9J0I9p/VYJ+zFVfysq9qn6BOB9gGEEfhbhT14kEnW8YfYVT29SVA25tyCtjlQy/aJCFihiK2n2vt+6V5xrtLln0p0LMGCby62/IF+3JnneYhYleuPOv+hEkJEELSdkjJdEkba44OfhaHBExmY3MxPTS9SenP+cq01STEfR+sqmXEItbJcjKyyirgfmZE/yOKfLGTac6MxW5UCVAkTF7tTwcq63N/urrx/keQ+XlElRjc8dE0RUSf3Elugiq/NwxUh3aok/n7NjrcaMyEdmM/fFpvseYvHwr/vnJ8vR3lcIQxGategGq7NYtKsvx8R1nOrZ97YRDpWWBcCM+r5SPMgLFnpHU5+tCSkw350QMoT3qL5n8Du6Vs0Bq5GQrjBt2Hogl+5gfTUbQH9W1tX8hCy+vG12bmlso6dh9j+/hzFTkRqVxuX3YWZYQBUDvTq3Sw9ie7f1dEZWLXAL2Y7e5SNd7xr1eIajZqZOHSUA3U5MOFyqEnsrdz0bltif6g89duxO/fHtR+nscrr9d2rTAL0Yd619Q4LCOzvvltdI1jGVv1dZgjgdBXmyy6nj1x6hzNEs3ZdyUZYIeAKb8LOO2/O8pqyKdT4cmI+hViylkeHUmXZfHXpJsPVFRaUoXHu8UNM9MXoVte7ODjF0qhJWNYhmUdQR30maRuFwAdY4j+ld7aYlxmka/rBhp/eqi4xz3XJf7L1QLYVXgrqCc1jd6sh8VYTR6O7CaLkE0+iBmrTB4zY/oyJ0wcX2C0mQEfRC8NPpzjnUO61QCw0ubDIuqWu4sWuMWbsryvwacZiYd7dirw1421CnAZLHJbdwTTmKS9iDoKLNiogkv4pwCu/hE+erOLm1a4KFvHo+BiuBuKtyTyiK9O6lty0HQXS0q4udBYhNGH77xzMwL+v4L5YHdRNyLu0b0V4cav+TEHlJHCl3cc0xufqtIZAPouV+Gcb0OihH0Erw8Cu5x2Ze9Jghf++GpAOTuY2FQmY3cE0sqm1/QCWGv4m6t3msOwi3o20qCdslwJxy/+tTs0ARudCeKVS+6MCnj/Ib6rZrHNynsdX1e7dZNENOHzXE+mbNswlg+xBg+3znJfzLUndJRFhs/Ux/CGZJUoLoc4rNGwUtnUs17iDz6wVLfMlFJTNAT0UgiWkJEVUR0V1LnSYKjJUGtbHQnXwFgYM92WPnQBegdkxlHpYW5G5NqKCjur+ORolojAATT2sJqz3+6bJDju04ERF2zgapzBpnw1iXqCmcblb3X5v1bnRP5S395XuhjydC9t1Ft3DpmGSJyPKu4vYDE2FdHKLyUbKKGx9jtsfI2LhIR9ERUDuAvAM4DcAyAy4jIfzyWEP/5QXZoVhl2eNogCaVzia5nwvod8kU5YjLmob074NffGID5D5yrPI6XfbmHMJnrlwN2+JGdcMmJPfDLi47zHQaLiILl8I56k6e6gxa3Rmgj87mOShh7uHt1JuAfTM8dmdJLYLZqXuEwd0y++2zfOgWR3+cKJk4vs4pNJyu94/cCxK1/5tpMv/Zrg20C9mnxxeHXJk4/qjMGH5ZtnnNHPM0nSWn0QwFUWekGawE8D2BUQufyZET/Ljilj56W9q+rv+Qp+PKNbmA0WYe8YEA3fPWEbkIZwmVDD8PBzSscftsiXi+WiwZlJoCHKwJTicd5+JIT8N1hh6cDd+kgXoau0qRrunGvorX5kaYdOgg3nN4Hn999VqB9ZO6L15+eHcgrCr+/JPMy8TNPAMEE/Y/OytzHHhoeXj3at8SE208P7E/vlUxd5KKBandKGUFGJa1bVOKVG0/Nej6y4Hj5IilB3x2AGKx7rbUt5+jYyGyaV5QH0ugGH9YOXx2g9icOy2d3nYW3fjQ8K5a7rhCzc7PaDDm8Pf5y+WBlYom/fEe+UtKLLq1bYET/Lvj+8N745UX+PvlhELU0XZdM+31wrI89uUubFpj/wLkYf/vpjjjsOnbu/wjJO3TKl5WRNA68F0SUJTi8fL9trtGYx7A5OIBNHwC6t9N3ST2ue2YNwZ0e6xlEjuh8cCDTKAA8efVQzPz5V3zLlZVlEpG/c7P/+oUw2PmbbfzMYxOtubu3fjQ8kfqIUBxL4rMOSnQxgJHM/H3r+xUATmLmm4Qy1wG4DgAOO+ywE1etis+X9OOl1di06wDmrduJ7w8/IssHOCrPT12Nvl0PxomHB8+CE4SJSzZj/KLNqNq8B/27tcF9Ht4IP3t1HpZu3I2+XQ/G3LU7sWrrPuypqceA7m0x+soTfQXNnycsw+/ez0wK3XtBf3z/NHmM+Vzy4+dm4b0FGzH1nhFaJrWGRsbD7y3BtcN7+w7nbTbuPIBhvx6PEf274h9XnqjU5tZs2weilPa5+0Adxs7bgG8N6amt/b00Y206fO3yB8/39YnfW1OP216cjU27anBCj7Z4YJT/C5WZMWPVdvTt2lrrfv17yip0bNU8HYvfj+emrsaZ/bpojQBenbUW+2obcLnG5GouqGtoxNy1O7T77ZY9NahraAz0kt5bU48Hxy7Chp0H8NhlgxIxBYoQ0QxmHuJbLiFBfzKA+5n5XOv73QDAzL+WlR8yZAhPn+6fws5gMBgMGXQFfVKmm2kA+hJRbyJqBuBSAG8kdC6DwWAweJDIuIKZ64noJgDvASgH8AQzR8tybTAYDIZQJGZAYuaxAMYmdXyDwWAw6GFWxhoMBkOJYwS9wWAwlDhG0BsMBkOJYwS9wWAwlDhG0BsMBkOJk8iCqcCVIKoGEGVpbCcAW2KqTqFS6tdY6tcHlP41lvr1AYV3jYczs2/UvIIQ9FEhouk6q8OKmVK/xlK/PqD0r7HUrw8o3ms0phuDwWAocYygNxgMhhKnVAT96HxXIAeU+jWW+vUBpX+NpX59QJFeY0nY6A0Gg8GgplQ0eoPBYDAoKFhBT0RPENFmIpovbHuBiGZbfyuJaLa1vRcR7Rd++5uwz4lENM9KUv4YRc1cHBOK6xtIRJOta5hOREOt7WTVvYqI5hLRYGGfq4homfV3VT6uRUXAazyDiHYKz/A+YZ+CTDSvuL4TiOhzq829SURthN/utq5hCRGdK2wvyOsDgl1jkfbDnkT0IREtJKIFRHSztb0DEY2z+tU4ImpvbS/KvghmLsg/AF8GMBjAfMXvvwdwn/W5l0e5qQCGIZWC9B0A5+X72lTXB+B9u34AzgcwUfj8jnUNwwBMsbZ3ALDc+t/e+tw+39cW8hrPAPCW5BjlAL4AcASAZgDmADgm39fmcX3TAJxufb4GwC+sz8dYdW8OoLd1TeWFfH0hrrEY+2E3AIOtz60BLLWe1W8B3GVtvwvAb4Q2W3R9sWA1emb+GMA22W+WNvAtAM95HYOIugFow8yTOfU0ngZwUdx1DYPi+hiArQG2BbDe+jwKwNOcYjKAdta1nQtgHDNvY+btAMYBGJl87fUIeI0qCibRvBvF9R0F4GPr8zgA37Q+jwLwPDPXMPMKAFVIXVvBXh8Q+BqlFHg/3MDMM63PuwEsQiq/9SgAT1nFnkKmvkXZFwtW0PtwGoBNzLxM2NabiGYR0UdEZGf/7Y5UYnKbvCUp1+QWAA8T0RoAvwNwt7VdlWy9YJKwB0B1jQBwMhHNIaJ3iOhYa1uxXeMCZAT1JQB6Wp9L6RmqrhEo4n5IRL0ADAIwBUBXZt5g/bQRQFfrc1E+x2IV9JfBqc1vAHAYMw8CcBuA/4i20SLiBgC3MnNPALcCGJPn+iSB6hpnIrWc+wQAfwLwWp7qF5VrANxIRDOQMgXU5rk+SaC6xqLth0R0MICXAdzCzLvE36xRSFG7JxadoCeiCgDfAPCCvc0aDm+1Ps9AyuZ5FIB1AHoIu/ewthUqVwF4xfr8X6SG9UCqzqLWZF+HanshI71GZt7FzHusz2MBVBJRJxTZNTLzYmY+h5lPREoZ+cL6qWSeoeoai7UfElElUkL+38xst81NlknGNj1ttrYX5XMsOkEPYASAxcycHgoSUWciKrc+HwGgL4Dl1tBrFxENs+z6VwJ4PR+V1mQ9gNOtz2cBsE1TbwC40prxHwZgp3Vt7wE4h4jaW14B51jbChnpNRLRIbYnhuWJUwZgK4os0TwRdbH+lwG4F4DtefIGgEuJqDkR9UaqjU5FkV0foL7GYuyHVn3GAFjEzI8IP72BlFIC6//rwvbi64v5ng1W/SGlKWwAUIeUvetaa/uTAK53lf0mUnbD2UiZAC4UfhsCYD5S2sWfYS0Sy/ef7PoADAcwAynPiykATrTKEoC/WNcwD8AQ4TjXIDWxVwXg6nxfV4RrvMl6hnMATAZwinCc85HyhvgCwD35vi6f67vZqutSAA+J7Q3APdY1LIHgdVKo1xf0Gou0Hw5Hyiwz16r3bOt5dAQwHilF5AMAHazyRdkXzcpYg8FgKHGK0XRjMBgMhgAYQW8wGAwljhH0BoPBUOIYQW8wGAwljhH0BoPBUOIYQW8wGAwljhH0BoPBUOIYQW8wGAwlzv8DyMZwQFJYTkkAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%matplotlib inline\n",
     "\n",
@@ -267,7 +479,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The plot command accepted an array of 'X' values and an array of 'Y' values. We used a special NumPy \":\" syntax,\n",
+    "The plot command accepted an array of 'X' values and an array of 'Y' values. We used a special NumPy \"`:`\" syntax,\n",
     "which we'll learn more about later. Don't worry about the `%matplotlib` magic command for now - we'll also look at this later."
    ]
   },
@@ -275,51 +487,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Naming Columns"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "I happen to know that the columns here are defined as follows:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "From [the data provider's own documentation](http://www.sidc.be/silso/infosnmtot):\n",
-    "\n",
-    "> CSV\n",
-    "\n",
-    "> Filename: SN_m_tot_V2.0.csv\n",
-    "> Format: Comma Separated values (adapted for import in spreadsheets)\n",
-    "The separator is the semicolon ';'.\n",
-    "\n",
-    "> Contents:\n",
-    "* Column 1-2: Gregorian calendar date\n",
-    "  - Year\n",
-    "  - Month\n",
-    "* Column 3: Date in fraction of year.\n",
-    "* Column 4: Monthly mean total sunspot number.\n",
-    "* Column 5: Monthly mean standard deviation of the input sunspot numbers.\n",
-    "* Column 6: Number of observations used to compute the monthly mean total sunspot number.\n",
-    "* Column 7: Definitive/provisional marker. '1' indicates that the value is definitive. '0' indicates that the value is still provisional."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
-   "source": [
-    "I can actually specify this to the formatter:"
+    "`genfromtxt` also allows naming the columns. Similarly of what we've done with the `csv.DictReader`. We do that by specifying the column information to the formatter:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -332,26 +505,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([(1749., 1., 1749.042,  96.7, -1. , -1.000e+00, 1.),\n",
-       "       (1749., 2., 1749.123, 104.3, -1. , -1.000e+00, 1.),\n",
-       "       (1749., 3., 1749.204, 116.7, -1. , -1.000e+00, 1.), ...,\n",
-       "       (2018., 7., 2018.538,   1.6,  0.6,  1.269e+03, 0.),\n",
-       "       (2018., 8., 2018.623,   8.8,  0.8,  1.111e+03, 0.),\n",
-       "       (2018., 9., 2018.705,   3.3,  0.5,  1.067e+03, 0.)],\n",
-       "      dtype=[('year', '<f8'), ('month', '<f8'), ('date', '<f8'), ('mean', '<f8'), ('deviation', '<f8'), ('observations', '<f8'), ('definitive', '<f8')])"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "sunspots"
    ]
@@ -360,19 +516,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Typed Fields"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "It's also often good to specify the datatype of each field."
+    "Going a step further, as we know what's expected on each column, it's then good to specify the datatype of each field."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -386,26 +535,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([(1749, 1, 1749.042,  96.7, -1. ,   -1, 1),\n",
-       "       (1749, 2, 1749.123, 104.3, -1. ,   -1, 1),\n",
-       "       (1749, 3, 1749.204, 116.7, -1. ,   -1, 1), ...,\n",
-       "       (2018, 7, 2018.538,   1.6,  0.6, 1269, 0),\n",
-       "       (2018, 8, 2018.623,   8.8,  0.8, 1111, 0),\n",
-       "       (2018, 9, 2018.705,   3.3,  0.5, 1067, 0)],\n",
-       "      dtype=[('year', '<i8'), ('month', '<i8'), ('date', '<f8'), ('mean', '<f8'), ('deviation', '<f8'), ('observations', '<i8'), ('definitive', '<i8')])"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "sunspots"
    ]
@@ -419,54 +551,100 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([1749, 1749, 1749, ..., 2018, 2018, 2018])"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "sunspots['year']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x10f978748>]"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXoAAAD8CAYAAAB5Pm/hAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvqOYd8AAAIABJREFUeJztnXl8VOXVx38nZCUBwhK2EAggiKKyGBFBURGVRcWlWpcqLpXXim211rexal2qldqqVftq3UXrXrWgKIKggqBg2AlrgAiEAGFJAtnI8rx/zB1yM3P3debmfD+ffDLz3Dv3Ps/M3DPPPc85v0NCCDAMwzDBJcHvDjAMwzDuwoaeYRgm4LChZxiGCThs6BmGYQIOG3qGYZiAw4aeYRgm4LChZxiGCThs6BmGYQIOG3qGYZiAk+h3BwCgS5cuIjc31+9uMAzDxBXLly/fL4TI0tsvJgx9bm4uCgoK/O4GwzBMXEFEPxnZj103DMMwAYcNPcMwTMBhQ88wDBNw2NAzDMMEHMOGnojaENFKIvpMet6XiJYSURERvU9EyVJ7ivS8SNqe607XGYZhGCOYmdH/FsAG2fO/AnhaCHEcgEMAbpHabwFwSGp/WtqPYRiG8QlDhp6IegGYBOAV6TkBGAvgP9IuMwBcKj2eLD2HtP08aX+GYRjGB4zO6P8B4H8BNEnPOwMoF0I0SM93AciWHmcD2AkA0vYKaf8WENFUIiogooKysjKL3feflTsO4b5P1vrdDYZhGFV0DT0RXQRgnxBiuZMnFkK8JITIE0LkZWXpJnbFLJc9vwRvL93hdzcYhmFUMZIZOxrAJUQ0EUAqgPYAngGQSUSJ0qy9F4ASaf8SADkAdhFRIoAOAA443nOGYRjGELozeiHEvUKIXkKIXABXA1gghLgOwNcAfibtNgXATOnxLOk5pO0LhBDC0V4zDMMwhrETR/8HAL8joiKEfPCvSu2vAugstf8OQL69LjIMwzB2MCVqJoT4BsA30uNtAEYo7FML4EoH+sYwDMM4AGfGMgzDBBw29AzDMAGHDT3DMEzAYUPPMAwTcNjQMwzDBBw29AzDMAGHDT3DMEzAYUPPMAwTcNjQMwzDBBw29AzDMAGHDT3DMEzAYUPPMAwTcNjQMwzDBBw29AzDeMK6kgocrq33uxutEjb0DMN4wkXPfYfx/1jkdzdaJWzoGYbxjJLyGr+70CoxUhw8lYiWEdFqIiokooel9jeIaDsRrZL+hkrtRETPElEREa0houFuD4JhGIZRx0iFqToAY4UQR4goCcB3RPSFtO0eIcR/IvafAGCA9Hc6gBek/wzDMIwPGCkOLoQQR6SnSdKfVrHvyQDelF73A4BMIuphv6sMwzCMFQz56ImoDRGtArAPwDwhxFJp02OSe+ZpIkqR2rIB7JS9fJfUFnnMqURUQEQFZWVlNobAMAzDaGHI0AshGoUQQwH0AjCCiE4CcC+AQQBOA9AJwB/MnFgI8ZIQIk8IkZeVlWWy2wzDMIxRTEXdCCHKAXwNYLwQolRyz9QBeB3ACGm3EgA5spf1ktqYALO4aD+K91f53Q2GYRQwEnWTRUSZ0uM0AOcD2Bj2uxMRAbgUwDrpJbMA3CBF34wEUCGEKHWl90zMcN0rS3HO37/xuxsMwyhgJOqmB4AZRNQGoR+GD4QQnxHRAiLKAkAAVgG4Tdr/cwATARQBqAZwk/PdZhiGYYyia+iFEGsADFNoH6uyvwAwzX7XGIZhGCfgzFiGYZiAw4aeYRgm4LChZxylsUkrl45hGD9gQ884SmUNy9AyTKzBhp5xlIPVR/3uAsMwEbChZxylnA09w8QcbOgZRzlUxa4bhok12NAzjnKIZ/QME3OwoWccIT25DQA29AwTi7ChZxwhPSWUZH2oml03DBNrsKFnHIEo9J8XYxk9QiopjJewoWcchRdjGT3qGpr87kKrgw094yiH69jQM9rUHG30uwutDjb0jKPwXTmjR3U9G3qvYUPPMIynLNxchsVF+/3uRqvCSIWpVCJaRkSriaiQiB6W2vsS0VIiKiKi94koWWpPkZ4XSdtz3R0CwzDxxL0fr8V1ryz1uxutCiMz+joAY4UQQwAMBTBeKhH4VwBPCyGOA3AIwC3S/rcAOCS1Py3txzAMw/iErqGXCoAfkZ4mSX8CwFgA/5HaZyBUNxYAJkvPIW0/T6oryzAMw/iAIR89EbUholUA9gGYB2ArgHIhRIO0yy4A2dLjbAA7AUDaXgGgs5OdZuKfez5cjdz82RyBwTAeYMjQCyEahRBDAfQCMALAILsnJqKpRFRARAVlZWV2D8fEGd9uDn3mRfuOYOgjc7GhtNLnHjFMcDEVdSOEKAfwNYAzAGQSUbi4eC8AJdLjEgA5ACBt7wDggMKxXhJC5Akh8rKysix2n4l35hSWory6Hm8v/cnvrjBMYDESdZNFRJnS4zQA5wPYgJDB/5m02xQAM6XHs6TnkLYvEJzzzKhQLmnjZKYlu3L8wt0VmPjMIleOzTDxQqL+LugBYAYRtUHoh+EDIcRnRLQewHtE9CiAlQBelfZ/FcBbRFQE4CCAq13oNxMQyqXSg5ltk1w5/m/fW4WifUfw04Eq9Omc7so5GGMQcUKdX+gaeiHEGgDDFNq3IeSvj2yvBXClI70LELsOVeOhWevx7DVD0TbZyO9r66BCmtF3SHPH0IeLlXPRcv8hhML1GO/hzFiPmP7FRny1YS/mrd/rd1diivKakNplu1T+8WMYt2BD7xFpSaHCHLWs89GC8mP69ZxqEW80NQl8tHyXoX0/Xb0b8psqzqzxFjb0HpEmVWDiuPGWVHChkrjluQVFuPvD1ViwUfsutWjfEfz63ZUt2jJS/L+Dy82fjdz82X53wxPY0HvEsRk9a3G34HBdg/5OTEyyp7Im9L+iTnM/pfKS7WLA0Lcm2NDb4KgJo52SxDN6hgmTwWsynsKG3gYVNcbdDuyjZ5hm0jjyzFPY0Nugoqb5ljQ3f7ZmvdS0pNBbXcOGnolxFmzci9HTF7h6jgRejPUUNvQ2iJzRby07orJn82Isz+iZWOdX/16BkvIa/q4GCDb0Nig3ETGSGvbR1/NirB98vKJEfycGACc1BRE29DYwY+jbSPeqvBjrD//8ughzC/f43Y1AUteg/Z1OSWQz4zf8CdjAzGJsGL4d9o+9lbV+dyGQPPzpery+eLvq9nap7shbKPHJyl2o4pDdKNjQ26CcDT3DAACW/3RIdVuyRzP6nQercdf7qzHtnRWenC+eiGtD/8GPO5GbPxvbNBZBrXLHOytw+fOLNfeptGDoOeqGYdyhsjZ0Pe6t1E7gao3EdTBruErR+tJK9MvKcPTYn60p1d3HiuuGDT3DMF4T1zN6v2mwIH1bx1E3DMN4DBt6jykpr0F9Ixt7xjq7y2uQmz8buw5V+92VY3y2phRPzdvsdzcYFYyUEswhoq+JaD0RFRLRb6X2h4iohIhWSX8TZa+5l4iKiGgTEV3o5gDcpqGxyfFojSfn8gXBWOfDgpA08Ac/7vS5Jy156/tiv7sAANhQWolDVepZ6q0RIzP6BgB3CyFOBDASwDQiOlHa9rQQYqj09zkASNuuBjAYwHgAz0tlCOOS2/69Aqf/Zf6xhR4ncPJYDMNEM+ZvX/vdhZhC19ALIUqFECukx4cRKgyerfGSyQDeE0LUCSG2AyiCQsnBeGH97goAwOFajs1lmHjBzPXaGjTpTfnoiSgXofqxS6WmO4hoDRG9RkQdpbZsAPJ7yl3Q/mFgGIZhXMSwoSeiDAAfAbhTCFEJ4AUA/QEMBVAK4EkzJyaiqURUQEQFZWVlZl7KMAwTRVuWPlbFkKEnoiSEjPzbQoiPAUAIsVcI0SiEaALwMprdMyUAcmQv7yW1tUAI8ZIQIk8IkZeVlWVnDAzDMEhPbrkU+MqibY6foyFOI+aMRN0QgFcBbBBCPCVr7yHb7TIA66THswBcTUQpRNQXwAAAy5zrcvwTr18WholpIjTuH529wdHDv7JoG4677wts3nvY0eN6gZEZ/WgA1wMYGxFK+QQRrSWiNQDOBXAXAAghCgF8AGA9gDkApgkhOB1URpClipdsPYAZS4r97gZjkZvf+NFUicyg8J/lu3T3Cev5FO1zXnLFbXSdWkKI7xD1WwkA+FzjNY8BeMxGvwJN0KWKH5xViCmjcv3uBmOBBRv3+d0FX/j9h6vxs1N7+d0N1+DMWB12VzgvbcsKlgwTv9z+9grMXBVfhWzY0PsAG3qGcZ7qOu+uq6XbD3p2LidgQ+8DrGDJMM6zKQ4XSb2CDb0PsKFnGOdRulP+sEBZD0jJ9fLm98UO9yh2YEPvA7UBX4xlGD9QkgC/5z9rFPf97Xurotr+NLMQRfuCeVfAht4HLMjYMwyjgxN3ylaKCcUDbOg9QsiM+57KWswt3ONfZxgmgHCQgzps6D3ixYVbWzx/aFahTz1xn8QEpbQLhnEXXvtShw29R6wrqWzxPMhfyoYmgate/N614+fmz24V0rKMOWoDnHFuFzb0PlEd8AXZZXEWZ8zEP+y6UYcNvU/UtUI9ESfgmTyjBht6ddjQM77gVeCRV6sFX2/ch9z82XFd+L0pzsPB2NCrw4beR3aX1/jdBd9o9MioJCd68xX/+9xNAIBNe9yPw05sE/r5Otro7Hu497Dzuk5eYmbdq00rCxhgQ+8jo6Yv8LsLvuGVFG5KUtzWpVelrVRgw+kZ7PayKkePp8ZZA7q4clwzi7GZaUm2zhVvCrRs6Blf8MrQp3o0o/eSNOnHq/qoswXrt+33xtC7hZkZPdmc0B+sOmrvAB4TvKuAiQuOeuTLDuKMPk2a0TtdwGa7CUNfW9+IlTvKLZ9r5Y5yxwvU1Lnoo/+ycA++WNec5HioOmCGnohyiOhrIlpPRIVE9FupvRMRzSOiLdL/jlI7EdGzRFRERGuIaLjbg2AYNYI8o69xeEZvxtDf+mYBNtpcj3jQ4aRBN+Po/zdCM+fAkYAZegANAO4WQpwIYCSAaUR0IoB8APOFEAMAzJeeA8AEhOrEDgAwFcALjveaYQwSxBl92+RQYTinczGq6oz/cBQfiD03j5dJiIGb0QshSoUQK6THhwFsAJANYDKAGdJuMwBcKj2eDOBNEeIHAJkRhcRbHXUN8bVw4xcHq446vsCYIpvRL9yyP+5DCIHmqBs/s6sTE2LvTsnL8Mp4S3g09WkRUS6AYQCWAugmhCiVNu0B0E16nA1ALgK9S2prtRyudfYWO6gM//M8DH1krqPHTE1q/orPW78Xj3+xwdHj+4mfkR8ZKbrlpj3HiR++AMwDFDFs6IkoA8BHAO4UQrQQbhFCCJjMgSGiqURUQEQFZWVlZl4ad1QGVPrUDZz2s6YktnTd7DhY7ejx/cTtGf2gB+aounPapcaeoVfSozdLcpvYu1NxAkOjIqIkhIz820KIj6XmvWGXjPQ/XD6+BECO7OW9pLYWCCFeEkLkCSHysrKyrPY/LqjkGb1vyGf0QcML94GaZpEdQ+9Gsty6kgpHIrmy2qUY3leI+Jn+G4m6IQCvAtgghHhKtmkWgCnS4ykAZsrab5Cib0YCqJC5eFolL3xT5HcXAskRA4uHkTP6IOFnpbJ2qdYTjsqrjd/h1hxtxFfr9+rut2Trfsv9sUpVHPnpjUx3RgO4HsBYIlol/U0EMB3A+US0BcA46TkAfA5gG4AiAC8DuN35bscXXxbqf1EZ85z04Je6+6QEMLwyTLWPi7F2ZvTlJiJWpr2zAr98syAm5UIOxlGIpe6nJYT4DuraUOcp7C8ATLPZr7ikvY1ZDuMOXmnd+IFXekFK2JnRHzIxow8b+IqaevTMTLN8Tjc4UFWH3p3b+t0NQwT3KrBBicXZQ3oMRiK0dlqXdJV3tLPxXQ9K0Z1fzijwuwuGYUOvwGiHxcb+Z0w/R48XTOJnYSuWyM2fjafnbfb8vLGm/uiHOvSBONK7YUPvAR3asktHjxcXbvO7C3HLM/O3+N0Fw4zI7XTscXqycwvlnJSoDRt6B2lwWB88yORG+DbtCGSpsWhLGR76dL3jx3WDnQerDUWX2KGhsckz1VAlnrjiFHxw2xnHnqfpGPra+kaUVoQ08ic8s0jTmAfFHeQWrdLQv7xwG15Z5PwMcszfvuaZhQGWbN2P3eXuF7m4/tVlUW1fFu7FnorYKbDx5NxN+KBgJ8564mv88k13fb4X/3MxBt7/hWvHNz/NUXf/fL1xHwY9MAcVsmTDd5buUN3fiWSpINMqDf1jn2/Ao7PdSYV/fXGxK8eNBS57fjEG3Pe57eNc+/JSz2SKlbjyxSWuHfui574zNWt+bkFRlDKiW2wordTfKQIzfugjDiYG3vTGj1FtWlFGXEZQm1Zp6N1k+hcbcSiOFmnMsHJHOeoD4J4yk7BjhTe/L3b1+F7y+w9X45OVuwzt2+BguGePDqmm9pe7brq3N/fa1gAbegcY1L1di+d3f7jap54EFyEEcvNn+90NQzhp8GKBdSXm7wTsMqRXpqn9e3RojrFPSoytiKBYIBCG/o53VmLmqig5HU/o1yUdf/vZkBZtZnS9GWPEkawI4wBmS/2df2LXY4+TAipMZofAvCM/bDvg6vFX71SPCkmxKJx18ZCeVrsTUxTuroi7YslO8sbi7Sjc7f2s1yrxJMZlhaAqUNqB3xGD3P72CqwrqVDclmpROCsrw7hSXqxSW9+ISc9+F5MKnV4pV8ZLCGcYt1xLXTKSXTmuWchu5e8AwobeBGoToUiDEm/VZ+xQ72P0jB6xWBzDK4QQmLNuDxoUPp86l2Lp98eRyFdrgw29CdQmCpF1SdeqzPzjldz82bhFIdzNCR6ZPNiV4wKtW3vom01luO3fy/GslDUrX8jmUMQQ14zI0d8pILChd4B4ksKtqK7HU3M3mX7d/I379HfyAaUZa5j05NZr6KuOhlxpRWVHora5NaMHgDnr4qf0REIrcvHEj4WKYeLJ0P/6vZV4dkERNu897HdXHOG4+75QdR/Zcd3k5s+Om3BOJcI/clV10bP3Ohdn9Lf9e4Vrx7ZK0BefjRA/FiqGiafFn3D9WiPVmdQoO1yn2H71aTm4bJj3deDVMlHbpgS3upQebSUdmeqjDdh/pOXn5eSMPqeTOxrxX6zbE9VmdQZuZLx2ZJfjASOlBF8jon1EtE7W9hARlURUnApvu5eIiohoExFd6FbH45WeJjP+YpHTHvtKdZufolmRtGYffVgwrKquEXmPtvy8nDT0p2RHJzbpfQfenzrS0g9EN4sZr0ZCf++/6ARLx44XjMzo3wAwXqH9aSHEUOnvcwAgohMBXA1gsPSa54mo9U6rFLhuZB+/u+Aqdu4UnCbDAR/9xj2V+HT1bgd64y3h2W/10ejPw8nF2MHZ7aPa9ITTTu/XGWcNyDJ9rq7trYUj+1lyMVbQNfRCiIUAlEvBRzMZwHtCiDohxHaE6saOsNE/Js6IJUPvhOtm/D8W4dfvrnSgN8bIzZ+NJgfj3JUKWDs5o7dTUtAsVl03NQo/dmGeuOIU3Dgq12KP4gc7Pvo7iGiN5NrpKLVlA9gp22eX1BYFEU0logIiKigrK7PRjfginhZurRBL8g/xGlWx42C1Y8dS+jzcXIyNRbTyWq46LQcPXeJeiG+sYNXqvACgP4ChAEoBPGn2AEKIl4QQeUKIvKws87dxbuJmmbSemWmBnUEQAYdlGbKvL97uY28YQNnIuRFeeWqfjvo7+USsJDDurazFR8uNKYE6jSVDL4TYK4RoFEI0AXgZze6ZEgDyLIReUltckerirLtzejIeumRwIFf5s9qltnDdPPzpelXZCMY/3EiYimU5j1jRYbr4ue9w94erNXX13cKSRSOiHrKnlwEIR+TMAnA1EaUQUV8AAwBEl/lxCLfesNQkd9aPH7joRJzer7Mrx44FenVMi3IVuK39boXsTHdCAuMFN2b0iW1ix03WtV3LH51YmdGHi7j4EddvJLzyXQDfAzieiHYR0S0AniCitUS0BsC5AO4CACFEIYAPAKwHMAfANCGEa+/ynMLoWFsncMvQX3d6b1eOGyv06pgWF1rsE0/uob+TDWJdYsDNzFi/uWxYNp6/bniLNq4nC+j6D4QQ1yg0v6qx/2MAHrPTKb+xKjvc2snp2FZ/pxjAyuwzN382Nv55vKFJQMmhGivd8oxYr2tsRyjvsmHZUfkTWlE3bpObPxtnDeiCt2453bc+AJwZq0i8Rmv4TXcHksE6pHkXrmeWylpjbqhxJ3ZzuSf2iPVC2k7fEfntulm0Zb+v5wfY0DMO4kRln4qa2PPpm6VzemzosqtRG+MzeqddLW4a+liW6ZbDhp5xlfZp5qOLlLI55cy58yyr3WFgbEZ/cnYHD3qijNNRMs9IUs1WKdp3WHUC8tp38RFCHChDn/foPLy8cJvh/Xc6mJjCKNPeQuaknuTAoO7Rafd6vH7jaRh3Qlf9HVsBRhZjbz4z1/2OqBBri6fjnlqoum1vpbLAX6wRKEO//8hRPPb5BtXtufmz8cnK5oSFs5742otuqfLa4u2458PVvvbBLnrKnVbWO77a4Lz2/cDu7fDPa4fr7wjgcY3vkBF+/e5KHKqK3WpLRhZjCf6tU6nN6K94YQmW/3TI0DHeudXa4uf8DXstvS7WCYyh14upDy/w3PW+O4bVqrTBh8t3YcaSYmc74yFJUgTLL8/sa+n1YxTErbSKiSjx3IIi/PuHn1Tjk/84cZAp1dAXTdwVKlFaUYs/fLTG1jHcxMvwyrqGRkx6dpGp10TO6LNkcfFGBeZG9e9i6pxhHphZ6Fv2qpsExtB/UGDtw3EqecFs7H2T7LwPzip0pA9+0tHiAmSXdilY+9AFuvuFbwwuHdozatu/vt2K+/+7Ds9/szVqW0ZKIqaO6e95zQC33A+Ha+vx1NzNto7hpdbNK4u2m06ai4y6+fuVQ449fmNJMaa97W5xk10GwmOvPb23qez2rWVHfMmIDRMYQ28Vpy5IszN6JVVBt3lu/has2lnu+XmdJLdLuuo2tYIoQeLuD1ZjWbFRMVllvJzRW6lPoBclM88F94rb78k1L/3g6vH1aBWGvqGxCYMemKO4zalwPreyaZ3kyXn2ZoJGCHr2r58IIXDQAd+/VtTN0JxMrH5Q/w4rzMCuGQCAEX07merDO0t3RFW+ChPpo/dCMuDR2cbWZcLibV1iWNtHiVZh6BduUZdBrqxxJmsulbNpAQCPXXay312ICRoanTdOl7+wBAUGFyO10FqMTUlMMJW0Nqh7e2z7y0TccEau7X6FiXTd/HTA/eg4o3ceU8f0w/2TTsCd5w0wdfyRPmtctQrrpDUhcGpGnxYHM/pYJQ7kcUzz/bYDjh9z5Q51t9vPX/ze8HFqHc6MTbAh66208B7pTh3V35qRfO3GvGOPc/NnO+Ijz+2cjl+e1c/0mJ1IJrRDqzD0Wmzee9iR4/zqnOMcOU4sUVrhjWZLrMjIxjNLtxv329vVunnr+2I88tl6W8e4ZEhoUV2pIlnN0ZbGf0C3dnj8cvN3imMHtZSi2F2u/n02ard7d7Kv5+SHxEqrN/T3/3edI6Xb2qWaywCVzzaAUG3S8f9QT8zwmoLigzjj8QUt8g6sMOZvX6NCJ+pCwPkp/fs/7sCrKlmLT8zZhDP/usDxc8YLZhceK2vqW/jJH5hpP0rszAGh8Ed5oZow1fXNbedLukEZFus3XD5MscBdFEaP74SN9uMGttUbeqBlqKNVjpqM/Y6cbdz1/mps3HMYRfuO2O6LE2wrqwIALCmy74J4eZG9uHSjyI3RHz5aC0D9s1ULobvjHXdD94xwzt+/cbX2rllD/+HyXfjjJ2sd7UN7aWK0obQyalut7A7v5RtCEyKrrtH2BtcbtGrfOl0k6IDKIrSbBN7QNzUJvOZQSbv6xibk5s/GE3M2Rm2zG5vc2NQk/Xfn937lDnOLeGnJoQur2oHwUyd+SI3w31XRyTRmBK3W767EZ2tKneySZf670r3CbFbUIbXWB6wQNqxT31oe5bpTCnl229uhdUdu9MfCKLsrah09nhECb+hf+HYrFjswKwWaizYrJWfFejGHy55fYmr/8Ayq1gX/uZksVTPIF9ZzOpmvImVX1fHaOAktVZpM5ObPNuXnN8rAbu0U2+WGNdKw1/ggoxye2CiR2dZhQ6+xVuAWRipMvUZE+4honaytExHNI6It0v+OUjsR0bNEVEREa4jImLiIi6jF6lrh7aU7VLd5XVVoxpJiHDaoj26FYzN6Fwz9WJm4mFsx0gO6KhsYN5lwUnfPz+k0Thv7TrKM6VLZTFbLVeLH4rzWDUOrMPQA3gAwPqItH8B8IcQAAPOl5wAwAaE6sQMATAXwgjPd1KZLhj39byVvySSFcnPb91epHsPpkDUttu+vwoOzCnHek9+6ZuzDCWBupPLLow6c/CGRX5BtbIT8OcWPNjNYtWirMQONVUYd1xwmqeUqqan3ryKUEk4UwzlS13ydlsai60YIsRBA5Dd2MoAZ0uMZAC6Vtb8pQvwAIDOikLgrKBllMzxlMGNUK8Xeyxl92LjvO1yHlxe5o4cdNpROz66O1DUoRlqYpXv7aPePFUlkJ4nMyfjFK0tdO5fXY92457BpcTI57946EqflNmfPahr6GAu3bZdi/73+srBZtiFWZ/RKdBNChFet9gAIh5BkA9gp22+X1BYFEU0logIiKigrU89c9YJ/fbsV+yrt/cp6OaM/cKQ5Df6IA0ZTC6dn9CP/Mh+fOLDQ+MMfz8M9Fx7fos2PSfxcWYH6tSUVLba5WSjdSkEXuxTujo6QsUpKovodid56l9fiYHYSwpSIy8VYEXKymn7nhRAvCSHyhBB5WVnRUrVeY9eFMLKfOa0PO8gNSLJFeWSj7HC4OIuRsMFVO8sxZ90e3f3skGjh4i0ojo5cmvrW8uYnJq+C3PzZpvsQpkcH84vNQcFPFUizKLmVS+NoRr837JKR/ocrRZQAyJHt10tqc4UeUvRGhslkJTc4vV9nTLeQvRfGCXdGUDhUXY/b/r1cf0cb9Mw0byhvf3uFq353OXrlFHt1TDOdpMd4j5L0wb7DdaZrLtjFqqGfBWCK9HgKgJmy9huk6JuRACpkLh7HyZN8fr33Iv+UAAAfQklEQVQ62k9LDtPYJCxHgthZAPRjgcYOufmzY64wcvGBasMJZz0zrYV47jrkTflJuU9XifZpSVHf+7qGxkAUVweAflnp+OT2UX53wzXKPE6aMhJe+S6A7wEcT0S7iOgWANMBnE9EWwCMk54DwOcAtgEoAvAygNtd6bXEfRNPQMe2SbjgxG76Oxuk/x8/x9ayKttp+dO/iE6qcoK9lbW49c0CV45tFi9UBc1y1/urDO0X666Pjm21I8napyahV8eWYxj8py8x5OG5bnbLM/p1Scew3h09O985x3tbT9iKTr8djETdXCOE6CGESBJC9BJCvCqEOCCEOE8IMUAIMU4IcVDaVwghpgkh+gshThZCuGqRundIxco/XeBKKN3na+35iP/1bXS1Iyf4aIU17ZnIt+jy55e4Jlo2qLv3MexhjIYdxrqsdEaK9jg6pEUbejcXf4POb84bcCz7tqEptu5UnSC2v+1MC9bvrsQTczZZeq1SYZSPV7izfDLzjtGuHNcITqerm8Gsz1zrR0kviislMQHZFtYZGHXCwmZa62V28/ueumqI/k4uwIY+xtCKKHj8C2NVcJTwUi9fK3Qu2WVdbj8XKG87u79jxrdKZzGWyNm1qTDv3Hq648d0AzcKeIdzE95YUozvtuyP2p6cmICkNi1vjWeuKsG3m/0NDzcCG3oNPvrVGZ6fUytuXcuA6uF1qUO1sE8nZ9xKSWp+Jk0ltkmwpJuuRJWBMNRI140TjOrfxfFj6mFF9O7uD1c73g+5VPG7P7aUO8lql4LNj05AYsRE5UDVUUx5bZnjfXEaNvQanNrHu9j4MGphdYW7K/CVjaLIKR77pDupLCZ2sJDoU1lbj773fh7VHpZSltNeY0bvpvDcz07tFdXW2CTw8KfWtNur6vTzOnJcmNE7gdk1s1gRBJTXvc3tHJvvrVXY0LvMlNeWmfKrqyVuzVtv3cgDQKqNuwErPHftMMV2KzP6NTsrFNuVQim1xLLcZPzgkKBZpJzu64uLLR3PSGKZH9mxUSjY9MYmgbe+L3b91HYSzpSYcHKzKF12Jhv6mOfxz7V92WYr1kcSznYzEm9v1n+nlyhjFa+jTPqozIicNMQXDI4Oq/X6ziVM2DVmxPUhhMA/vtqsmY1t5HtAsl8Vt9c+1FCrzOREFSo/ifTFxzuBNPQvLlSvaJScmICzB9qTXAjH7X+2phTbNBQtrSDXsXESr3306cnKBiDyrl7tcuqfla7YvrG0ucbvXeMG4qwBxn3KbipapiUnHDvHH8YP0ty3pLwG//hqi+Y+eq6byLF01lFwNRvyaiSPpH1qYkyohDL6BMLQmym7ltMxDb88q6+t82WkJrqmo+5WxpwdQz/uBPPJJEaifHp0SEXX9qno2s54luocmYhYQgJFjetPMwtx+fOLFV+bkZKICxXuApxAvlCeoqM/ZGRRXa80ZVZGSovnct33SIiAj37VnGVa19CE3+ssZu6pCH0P+6n84AJAB4d02kdPX2A7p+OI9MOo9d6nO1wSMJ4IhKGvbzRmdJMTE/DJtNG2olfCbNxzWH8nC1QbWISzgh3XTTiML6dTGobmZBp6jRHFv+/vPQ9AaHZaPH2S6n5my8it0Ch79+L1eejaLkV1u1XkFYr03EdOlMWLnElrKUv27JAWZeT+s3wXtpapy0Vs3x/adkKP9qr7ROq0Xzq0p+q+eiz/SbvUpd6dw0ap9uzxGncu8mPsP3I0qmxkZY05t6lTP3ReEAhDH/kVGN5b2Rj97WenGA6/++p3YwCoqxwu2mI/drZ4+qQoA6cXP22VBBvWpeZoIzY/OgHf/v5c5PUxn5b+/o87Ta09HNc1o8VzeRih27VDrSK/g/HLX24WrRoKt59zHMad0BUXn6Je6yEzreVdxD+uHoZhKteeXc4emKVZHnJ9aSV6dkhFpo50hJxIXaAdB825YU/q2cHU/n4SH99Ik2jdxhrlOKkUXaLKooxTdWgj+XhFSZRw1iOfrlf16QphXYTNKDX1jUhOTLCsy32g6ih+866+Bs3ZA7Pw9M+HRM3KSLPQmzZ2q48ZRe5CSvF4PcQNcruk45Upp2m6O5yovGQUIsLXd5+jun1DaaXm3YecJpWkRLO1HU7KNna+WCCQht5JkhKU3yIjKoE3WEykiAylfG2xehWpFxduw+MuCaiFcaLcX9lhfXXOGTePwGXDouPR5fx58kmGz3lCj/YouP98w/vLueGMPqb2l8/oUyP8xM9/U2SpD07WO3YDpVBZO3eOeqhNZ2rrG7G1rAon9jRmeGeudkb646RsntHHJUqKcmozeiMs9Cg1eqtBaV6rOF0mMSUxAc9cPdT06568cgh+MdKcAbaKWSkF+SJg5IxeK4/i8mHNBdgiQ1L//Nl6U31Q43fnD3TkOJEoFc1Wc5vqsbdS/0dNTR7ktcXb0dgkkNNJP/b9cG097nrfmazawTLXTayrhrYqQz9Yw6e2/0gdBt7/RVS7UuEANWo1MvyS2pCpY0W+VotUlwtFOx3bP6h7O0weqlhhMm6Ru7UiZ/RaaK3JNBgMMtDi5RvycIVC1q4TKLluxp9krX7znz9bj3//8JOl14Z/SCsV7rIj3Zpms3Bnrd6tqhibJVvUj/U6AK3K0Ecu8snZo1Iz9omfnaJ5zPsmnnDscb3GlyinY1vLMcdmwg/N8LcvN2FxUbR4UyQ1GkqKy7Z7U3HJa+QVqHp2MPf+m/HR79MoOK+FnTtNp1Ay9MMMRmUpUbhbOQM6jN71ozSRslvz+DfvrnRUO/5gVShPZvUu7bE6jS1DT0TFRLSWiFYRUYHU1omI5hHRFum/d9UDFAhfSFoaKFqcc3xXXKkyIxozMAu3jul37PmgHuqhXb1taGd0N2lozPDPBfr+45tH5yq2r9lVjutfjX1BJyXeXbYT5z/1rer2U7KbDdaNKuNXQy+OXs4+DZeFmquiX5d0DJeKcphJGLPLtaf3bvE8U8lH72ICVVKbBLx768gWbXoyCAer3J1pn2hwAThMOFP+N++uxFoPjb0TM/pzhRBDhRB50vN8APOFEAMAzJee+8YGKb42MjX9V+f0d/xcWtEhfQz4D9Xo3r7Z0P967HGWj6PE99u0o4dev/E0XJmXo7jNTKKaWX46UI23l1q7lU836MraorG2oRWPrYeZ5DStBLlIt074s1/w+3OOyR+8dcvp6NtFPalJzvL7x+EijXBJJeSVrtpFROB4GXUT5oz+nU3tf6janUxzq8hlK8prvOubG66byQBmSI9nALjUhXOYJvJW9w/jB3mavt27s7GLEQAe/nQ93vy++NhzeQKOF1IGtfWNeHKuvhCbmsyBEzQ0Cdz3yTpLrzUjnLZHpVavmsyyEczM6LXcApFSxQTlPAKj4bWdM1KQbVLaWOsasZsw1NGDhKNDVc4Y01oDkWdatSQAYNLJPfDIJYMd6Y9Z7Bp6AWAuES0noqlSWzdZQfA9ANzJOXeYRz9TF0KTq9pZxazsqVcRO0C0oXhwZiEWKRReAFqGuOnpq3iJXAfejCb9yMfnH3sc+T7cNW4gbopw2xipMmfG0GthNKy12KfavX7M6M1y0KEZ/WEDd6/9/xgtpS3n/64bjtwu6fjPbd7XubD7jTxTCDEcwAQA04hojHyjCF05ij9zRDSViAqIqKCszP8KLWqLsQAwdlA3S+GActTUHGOBK15Y0uK51i1lsUzELVa1QzbtPYwfi9UXidUWQMsi2n87bgAevLjlDEzruGGcuuuy4xpzSuNdHmb64sJtmCorTB8Phr682p6PfmA39QCOeMKWoRdClEj/9wH4BMAIAHuJqAcASP/3qbz2JSFEnhAiLyvLnppkPOB02bfbzu6PF64bruuPzs2fjT9+slZzHy1tmEhuP9fZNQK3sHKBG6mtbSS+PnJGPyLXmCz2lDNyWzy3mqg2Y0lx1I+3VXp1bIsnrmiOPJsrS+ZTkygOU1mr/Rm0UUlGjAXu+c8aPDt/i2sRb15j+Z0monQiahd+DOACAOsAzAIwRdptCoCZdjtplq827HO8KIERcru0NOYnyzLn3PCtTzi5h6GInHeW7tDdxyinyrRuNpkQdnNXpME7jGR+Ws0OvfnMvi0iW6zO6LUEwhotxOZfdVqOoige6YxznU5UyYvXn2q6L2aZKouKi0RPYfWpeZsd6cNVeb0URfuuf3UZdh70xu1m5ye1G4DviGg1gGUAZgsh5gCYDuB8ItoCYJz03DN6m4hume5Qfc8wPTqktfhAj+uagWtG9EaXDPtqiZ3TkzHvrjGui3p9WbgHXxYaq2ZlJgY8rCNSW9+oayAiJXidxo7KohESEggb/zze9nHuHDfAgd605JXv1OU0nEYvVvzUPh3xf9cOd7UPf5x4Ah646ETFbWsfusDQMdKT2+D565T7aaXerZw739fXgHICy4ZeCLFNCDFE+hsshHhMaj8ghDhPCDFACDFOCOFZRk2fzm1b3Fq/8M1Wzf2vzMsx/GHbwQnjnJbcBgO6tcNZx4XcXGMHNWvEz15TiufmaxeyiJRkVePuD4ynhx/Q0WKRK38eqj6K+z5Zix+2HdRVwJSHC6oJUIWZdHIoXPBkBd2ROpVkmawImeJBD4QyotWuWbl8rVGXkBN3cH06GY/UikX+OseaBlPh7kp8tUHR42uLIQ/PRd6jXx17HlnoW41BPdpj4snKYan7bRYKcjIZS4vYdZKZIBx+GBnuZ+SL1i41qYUP0g/+52z128tITu7VAcXTJx0rhxheEH3SodtMI4Tt90Gd0LVbZAVeDlXX423JhTRJJ5ZbXuxC767h0mHZKJ4+CT0UXFh7VRbYI++waqXMXzWph817m11U7xfsxFsWU/UjOa5rBubdNUZ/R4SqUi3ZesCGjmc0B6uO4sCROkPhmbUa2dGtmVgXngsTCEPfo0MabhyVi1em5OnvrED/ruZnTqt2lquGQN5hcsHy3gknKKzuhy7pC59eiI9XqKvtKRk4K3wnhVMa8Qt3Sg8ZSr2yh2phjnrFS+Qz+p2HrPswq1QWMyNn9GHUfrgidUzW7DS+eK3FlDP6YEC3lolZlwxRdis9PW8zVu8qx90XHO/IuYGQj/jUR79yzBftBG4m4XlJU5NAbv5slKrkaXhNIAw9ADx0yeAW+iR2eOeXp9t6/e8vPN7UWoESw/uEjOGmvdoLnj06GB9zv6x0TFGR3/3Fq0uj5JHVCMtJHKiyNpvR89H3lI3pqw3G+mQGPUMfWTgkUu9o+U+HkJs/G78z6F9dVnzQsLrhyH6dMVdhlt/Q2ISemWmYZjPq6V+/iPY1z3fBTRImXHtWrQZtQ0RiwkkPfulaX7zEqfBWpwiMoVfDigLgqOO80w9RI9vgj1bPTOMz+m1lVXjoksG4LkKzJMx8o0ZVstMHdFw3agZVD7leyovfbsNum/VEI1HrV3g8kYVr+nRObxF1Ei4I//FK47rmsaJuqKQuub5UvQyhXcKKlJ+uVl4jmrNuj2L7zGmjXetTayTwhn6HyfClG0fl6u7jRCEOpzAzowdCs2kziS5aPkj5wqTSoulVeTmYdq59TSGn/aBqUT3hH9e/6iiWMtrIwxZX7wxF3qgtjJ/etznHQL5UMLCbutbQ4vyxGGRDi0iN47u3FCj7mQV556U62lF+EXhDb5YBBjLhjIYVfrKyBO8ucy6GXQkzM3otUpMSFAWgtC44OdUqF/IEi/rkbtJRpa5oZW09MlIScfZAdxL4wto1b33fcjFXrVj5tHdW6Er3xiIbZKGl4QXxrPbKY7xxdF+ce3zo/T7a2OzuSNNIBMzOTMMpvZyv7jTplB74m+xH3qw8NQD8/KUfUGEzG9cN2NBb4D2XjbcZ1Gb0QghTSWO19U1R8fO/O38ghhjUF48U4ArTYCTdVIdwCFpJuboLx8xp1KR0D1YddaTesBqDH/wSn6zchWciQmGX3TdOMaEGAKa89qPp88RSAfXw55+aqG647xwXqoC1fb/x4twP2RQHu+dC5UXtM2Wyz/sO1+lq3CzJHxvVVh+x7tBR4zu1tsSbH3I29BZwwHbp8ujsDVhn4EugNhu0WtBCjhlxTzejJT6RfOHPLVDPFVAqd/iH8YNMncdtQw8Au8vNRWHUN5pf1PNSldUJwpnEK01IcbS1qZyaqPIehZMeiYD3ftyJ1ToRVmoBIPJEKrsL6E7Qagx9OxOKhrFA2eE63Pi6/mxOnvThh+xDGLUZvVX+cllz1nJYSbOPhtRzTqe2LTIgLxzczVTNgf1H6rBoy37bmY5+8MzVQ/HRr0Yde64Vjgs4F5Iba3Rrrzyuch806Rtl3yMzaqpu0WoM/eXD1WuUyg3Ilr3KxSj6Z5lTsZNnjTZYmJUB1hYhjWqTO01VnbKPvrPFGXJkNSNA/e4lzC1n9jVcdKR7hFF4V0rmWqOStu9U6K4bTB6a3UKDSI9MlTUKv8jumKaopWMWtWO8sbjY9rHNonUZeuERiKRVGPrendriNA0FwS4ZKXj9ptMAqMvQnpTdwXAWI9AyWeeQgcWZcKSC3cpXW8tCfk6tcD6121Y7qLlucjq1xce3j1LcZhYnfc+RstR6194pChILVvhmk3sx63ZR03NRYt3DFzp23k7pyZh759mOHS8SP+S0Z65Sv6vSKgjvFq3C0Mt1YdQwIqRlt6KOFs//4lRcPjzbUkhXOGoBaNaW36pRJm/q2c6XUdRy3YTrm8Yy4f5HJks5zY/F6sqSSlTU1Dueuaoktfy78weq6rkAwAf/07JYhp5EcSxhZc3Czo1x3qNf4U8zCwEoVyobMyALE05qLmbkxY9/qzD0Zutk+kF2Zhqeukq9uInRL15FTT0OHKlTrEUazorNSEm0nf0bidM+eq95ceE2ANHJUkZwQqlSi2d1BOu0UHLlvWBi5h5mRF9jmvpMS5R+Y9okEC4f3jyhM7IWZ7sfrp8hBojVSkhm0AotjKSuoQn/UlDufHjySY705ebRfaParGbBxhpma6oC6kqV/bPSccVw9Ts0rbA7pyhXcOF1zkjBrWdFf4bxjto6ipkawkr4te7lJIEz9E7V61TCTDFstbhoPfQKDBthXUkFdrsopvSLkX1wg0wzZ9wJXfHKlNNcO5+XmBWk69dFPRJo/t3n4MmrhqhuP7FHe8V2J74DYXYdck4+YsbNIxw7ltPMnDZaNblvxk3R383NKkEXYeTXr9oCfZhtf5mous2NgkNWCJyhP0Hl4nGC9JREUwuLlw7tiZH9OmHR/55r+DVOqN2pyfOaRU98LEzn9BRPZvT5409w/RxmJwrbTCT5RJKrEi6qJNthQbIJADDEwQxStzKGI/nntcNMv0bruu/aPhU/z8tp0fbRil2Gj62X9KeWgJealIB3bx2puM3rTAfXDD0RjSeiTURURET5bp0nEjdSo+WYWVj8x9XD8N7UM5BjQsnSq0IESQYMWl+N2aqcgx7EKY8d1BUnu/zZeo2agTj/hG5RbZ+u3o0Sndn5DRHKpB/fPgrnKRwL8D7E8vR+xnz8OZ3ScNEpxiqAXThYeWxGMLMWo+V+0+KvV5yi+gPktavTFUNPRG0A/B+ACQBOBHANESnX83KYk7OjU/aPN6DXEn7j3bwj8Aojt/55fTpieO9MfH/vWOR0UvZtjh/cXbHdDn+ebC913W+88G0nJBAK7h8X1a43s3wkYg2mrUZOwa/O7n+sOhcA9LKwNmGUZ64eilH9tRVh01NCfe2VaXxS9OL1eUhqY2xuHBn9YmZGreV+C3PT6FwTRwSOl4myGbFPdnFrRj8CQJFUbvAogPcATHbpXC2IFCUrnj5JdeYkp1v7VCz633PxV5+rTYVD33I7W9ezV5I/ODNCepmI8PHto1W1cp644hRD7xugbVDCFE+fhOLpk3D9GbmGjgkAJ2U3/+ga1cxpKy2868lTX6xS4KNGRZwtTD+TiXMAsPKB8zUT9pTo1DY56jtw7wRzkg5aJCRQC70XrdBKL+ickYIZN4/AqzeaKx4UTmTUC6G8Z3xLbZtLHK4b/ODFg6OKB6klEQIh3314HUCv5oQTuGXoswHslD3fJbW5TpKNOOicTm1Nxdwq1Sm1y8h+nXHjqFzM/s1Zlo/xQUG0//HfGuGUbRR88efq5B78/LSQz3NY78yomaRTkGzeZTTD9r6JIT/+xj3aF89z1wzD/LvPxju3no5zZHkIatom4apaPTPTsP1x9cU3JTqmJ0ctFKr90IRJSCD8/cqWM8n/MZD/IK/epRc8ENaYOS23o+OLhvPvbk6AUorbV+LsgVmmNWw+uX005t41Rve6bZ+ahDelxeQbR+XiwYudv7P8+Wkts7nVKtBFEulycwPf4g6JaCqAqQDQu7dyIQyrvHHTaXhl0XbHC1aEOTm7A64Yno0bFcIMnSCszDe8dyZWSEJPIzV8nFeP6I205DZon5qE6qONaGhqQmpSG3y8ogQXDu6G23QMxCOTT8Jd76/CgaqjOPO4Lli3u0LXhzi4ZwfLkUVGeWTyYFz2fCgBzKha4aXDslFZW4+cjvp3RP2zMtA/KwMd0pLwzabQRan2md47cRA6ZyQfW5C8aXQuxgzMwlkGi9RclZeD6roGvLRoG2rrm/DARfoLy3m5nTCkVwes3lWB60caMwZv//J0rC2pQJeMFN21oZxOaXj2mmEYd4J+QmGYf/3iVEU560j6Z2Vgwd1nY8IzizB2kHVfuh5pyW0MS2mPGZiFey48HlPHGKvR/P7Ukeiqop+jxC1n9sW1I3pj0nOLsK2sCr9XUciU4/Y1FIbciBElojMAPCSEuFB6fi8ACCEeV9o/Ly9PFBQUON4PhmGYIENEy4UQuv4ut1w3PwIYQER9iSgZwNUAZrl0LoZhGEYDV1w3QogGIroDwJcA2gB4TQhR6Ma5GIZhGG1c89ELIT4H8Llbx2cYhmGMEbjMWIZhGKYlbOgZhmECDht6hmGYgMOGnmEYJuCwoWcYhgk4riRMme4EURmAn2wepguA/Q50J1YJ+viA4I8x6OMDgj/GWBtfHyGErn50TBh6JyCiAiMZYvFK0McHBH+MQR8fEPwxxuv42HXDMAwTcNjQMwzDBJwgGfqX/O6AywR9fEDwxxj08QHBH2Ncji8wPnqGYRhGmSDN6BmGYRgFYtbQE9FrRLSPiNbJ2t4nolXSXzERrZLac4moRrbtX7LXnEpEa6Ui5c8SKZRT8gmVMQ4loh+kcRQQ0QipnaT+FxHRGiIaLnvNFCLaIv1N8WMsSpgc3zlEVCH7DP8ke40vheaNoDLGIUT0vfS9+5SI2su23SuNYxMRXShrj8kxmhlfHF+HOUT0NRGtJ6JCIvqt1N6JiOZJ19U8IuootcfdtQghREz+ARgDYDiAdSrbnwTwJ+lxrsZ+ywCMRKge8BcAJvg9Nq0xApgb7iOAiQC+kT3+QhrHSABLpfZOALZJ/ztKjzv6PTYL4zsHwGcKx2gDYCuAfgCSAawGcKLfY9MZ448AzpYe3wzgz9LjE6X+pwDoK42rTSyP0eT44vU67AFguPS4HYDN0mf1BIB8qT0fwF9l39u4uhZjdkYvhFgI4KDSNmk2cBWAd7WOQUQ9ALQXQvwgQp/EmwAudbqvVlEZowAQngF2ALBbejwZwJsixA8AMqXxXQhgnhDioBDiEIB5AMa733t9TI5PDd8KzRtBZYwDASyUHs8DcIX0eDKA94QQdUKI7QCKEBpfzI7R5PgUiYPrsFQIsUJ6fBjABoRqXE8GMEPabQaa+xx312LMGnodzgKwVwixRdbWl4hWEtG3RBSurJ2NUGHyMJ4VKbfBnQD+RkQ7AfwdwL1Su1rBdd8KsVtEbXwAcAYRrSaiL4goXCQ23sYHAIVoNtRXAsiRHgflM1QbHxDn1yER5QIYBmApgG5CiFJp0x4A4eK3cfc5xquhvwYtZ/OlAHoLIYYB+B2Ad+R+0TjjVwDuEkLkALgLwKs+98dp1Ma3AqF07iEAngPwX5/65wQ3A7idiJYj5ArQr6YdX6iNL66vQyLKAPARgDuFEJXybdKdSNyGKMadoSeiRACXA3g/3CbdCh+QHi9HyN85EEAJgF6yl/eS2mKZKQA+lh5/iNBtPRDqt3zmFB6LWnusojg+IUSlEOKI9PhzAElE1AXxNz4IITYKIS4QQpyK0IRkq7QpEJ+h2vji+TokoiSEjPzbQojw93Ov5JIJu5/2Se1x9znGnaEHMA7ARiHEsVtBIsoiojbS434ABgDYJt12VRLRSMmvfwOAmX502gS7AZwtPR4LIOyemgXgBmnFfySACml8XwK4gIg6SlEBF0htsYri+IioezgSQ4rESQBwAHFYaJ6Iukr/EwDcDyAcfTILwNVElEJEfRH6ni5DnI1RbXzxeh1KfXoVwAYhxFOyTbMQmphA+j9T1h5f16Lfq8FqfwjNFEoB1CPk67pFan8DwG0R+16BkN9wFUIugItl2/IArENodvFPSElisfCnNEYAZwJYjlDkxVIAp0r7EoD/k8axFkCe7Dg3I7SwVwTgJr/HZXF8d0if4WoAPwAYJTvORIQiIbYCuM/vcRkY42+l/m4GMF3+nQNwnzSOTZBFnsTqGM2ML46vwzMRcsuskfq+Svo8OgOYj9Bk5CsAnaT94+5a5MxYhmGYgBOPrhuGYRjGBGzoGYZhAg4beoZhmIDDhp5hGCbgsKFnGIYJOGzoGYZhAg4beoZhmIDDhp5hGCbg/D+ozxF1p1FuWwAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "plt.plot(sunspots['year'], sunspots['mean'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Pandas - a more powerful CSV reader"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If most of your work is going to be working with CSV files, then, most probably you will enjoy the powers that [pandas](https://pandas.pydata.org/) provide. Whereas numpy uses arrays, pandas work with [DataFrames](https://pandas.pydata.org/pandas-docs/stable/getting_started/intro_tutorials/01_table_oriented.html), that's how they name to their representation of data in a table (2D arrays).\n",
+    "\n",
+    "Let's see how we would use it for this example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "spots = requests.get('http://www.sidc.be/silso/INFO/snmtotcsv.php', stream=True)\n",
+    "\n",
+    "sunspots = pd.read_csv(spots.raw, delimiter=';',\n",
+    "                       names=['year','month','date',\n",
+    "                               'mean','deviation','observations','definitive'])\n",
+    "sunspots"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In pandas, then you can access to the data of their columns as with a dictionaries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sunspots['year']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And ploting the data is directly available from the object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sunspots.plot('year', 'mean')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note how, automatically, pandas sets the axis labels and the legend. We will learn how to set these up later in this chapter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can learn more about pandas with the [Software carpentry's Plotting and Programming with Python](https://swcarpentry.github.io/python-novice-gapminder/) lesson."
    ]
   }
  ],
@@ -475,7 +653,7 @@
    "display_name": "CSV"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -489,9 +667,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/ch01data/062csv.ipynb
+++ b/ch01data/062csv.ipynb
@@ -392,8 +392,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Python standard library has a `csv` module. However, it's less powerful than the CSV capabilities in `numpy`,\n",
-    "the main scientific python library for handling data. NumPy is destributed with Anaconda and Canopy, so we recommend use that when available."
+    "The Python standard library `csv` module seen in the preceding section is less powerful than the CSV capabilities in NumPy,\n",
+    "the main scientific Python library for handling data. NumPy is distributed with Anaconda and Canopy, so we recommend use that when available."
    ]
   },
   {


### PR DESCRIPTION
The csv module section had been removed due to problems with the data
downloaded. This has now been fixed on our other course notes. The content has
been almost moved through, but leaving a section about how to read the data with
Numpy.
Additionally, the section has been expanded to include a very short introduction
to pandas.