### PR TITLE
Remove mention/use of Python 2 from discussion about types

### DIFF
--- a/ch00python/023types.ipynb
+++ b/ch00python/023types.ipynb
@@ -66,7 +66,7 @@
     "collapsed": true
    },
    "source": [
-    "Zero after a point is optional. But the **Dot** makes it a float."
+    "The zero after a decimal point is optional - it is the **Dot** makes it a float. However, it is better to always include the zero to improve readability."
    ]
   },
   {
@@ -142,109 +142,68 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The meaning of an operator varies depending on the type it is applied to! (And on the python version.)"
+    "The meaning of an operator varies depending on the type it is applied to!"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0\n"
+      "3\n"
      ]
     }
    ],
    "source": [
-    "print(one // ten)"
+    "print(1 + 2)  # returns an integer"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.1"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "one_float / ten_float"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<class 'float'>\n"
+      "3.0\n"
      ]
     }
    ],
    "source": [
-    "print(type(one / ten))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "float"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "type(tenth)"
+    "print(1.0 + 2.0)  # returns a float"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The divided by operator when applied to floats, means divide by for real numbers. But when applied to integers, it means\n",
-    "divide then round down:"
+    "The division by operator always returns a `float`, whether it's applied to `float`s or `int`s."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "3"
+       "3.3333333333333335"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "10 // 3"
+    "10 / 3"
    ]
   },
   {
@@ -291,14 +250,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "So if I have two integer variables, and I want the `float` division, I need to change the type first."
+    "To perform integer division we need to use the `divmod` function, which returns the quotiant and remainder of the division."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "quotiant=3, remainder=1\n"
+     ]
+    }
+   ],
+   "source": [
+    "quotiant, remainder = divmod(10, 3)\n",
+    "print(f\"{quotiant=}, {remainder=}\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There is a function for every type name, which is used to convert the input to an output of the desired type."
+    "Note that if either of the input type are `float`, the returned values will also be `float`s."
    ]
   },
   {
@@ -309,10 +286,37 @@
     {
      "data": {
       "text/plain": [
-       "float"
+       "(3.0, 1.0)"
       ]
      },
      "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "divmod(10, 3.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There is a function for every built-in type, which is used to convert the input to an output of the desired type."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "float"
+      ]
+     },
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -324,22 +328,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "3.3333333333333335"
+       "(3.0, 1.0)"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "10 / float(3)"
+    "divmod(10, float(3))"
    ]
   },
   {
@@ -1341,7 +1345,7 @@
    "display_name": "Types"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.9.13 ('rsd-course')",
    "language": "python",
    "name": "python3"
   },
@@ -1355,7 +1359,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.9.13"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "56f3b33ce8ef81dba99c545090023eafaf7aedb33c344d352a9ab6fb4e2c3676"
+   }
   }
  },
  "nbformat": 4,

--- a/ch00python/023types.ipynb
+++ b/ch00python/023types.ipynb
@@ -147,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -164,7 +164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -188,7 +188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -197,7 +197,7 @@
        "3.3333333333333335"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -217,7 +217,7 @@
        "3.3333333333333335"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -228,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -237,7 +237,7 @@
        "3.3333333333333335"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -280,7 +280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -289,7 +289,7 @@
        "(3.0, 1.0)"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -307,7 +307,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -316,7 +316,7 @@
        "float"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -328,7 +328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -337,7 +337,7 @@
        "(3.0, 1.0)"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1245,7 +1245,7 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-52-3331a3ab5222>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mzero\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mone\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtwo\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mthree\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mrange\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m7\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "Cell \u001b[0;32mIn [52], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m zero, one, two, three \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mrange\u001b[39m(\u001b[38;5;241m7\u001b[39m)\n",
       "\u001b[0;31mValueError\u001b[0m: too many values to unpack (expected 4)"
      ]
     }
@@ -1266,7 +1266,7 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-53-8575e9410b1d>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mzero\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mone\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtwo\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mthree\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mrange\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "Cell \u001b[0;32mIn [53], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m zero, one, two, three \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mrange\u001b[39m(\u001b[38;5;241m2\u001b[39m)\n",
       "\u001b[0;31mValueError\u001b[0m: not enough values to unpack (expected 4, got 2)"
      ]
     }
@@ -1345,7 +1345,7 @@
    "display_name": "Types"
   },
   "kernelspec": {
-   "display_name": "Python 3.9.13 ('rsd-course')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
Changes made:

* Remove examples and discussion of Python 2 from `ch00python/023types.ipynb`

* Change discussion about how the behaviour of operators depends on the types of the operands
   - Previously the discussion was around the Python 2 behaviour of the division operator
   - Now the example is of the addition operator applied to `int`s vs `float`s

* Mention that division always returns a float. To perform integer division the `divmod` function can be used

* Added note about always using at least one digit after a decimal point to improve readability