### PR TITLE
Fixes building sample repository without being on a git repository

### DIFF
--- a/ch04packaging/03Packaging.ipynb.py
+++ b/ch04packaging/03Packaging.ipynb.py
@@ -113,8 +113,8 @@ requires = ["setuptools", "setuptools_scm[toml]>=6.2", "wheel"]
 [tool.setuptools.packages.find]
 include = ["greetings*"]
 
-[tool.setuptools_scm]
-
+# Add setuptools_scm if you need to generate version numbers from the git hash
+#[tool.setuptools_scm]
 
 # %% [markdown]
 # We can now install this "package" with pip:
@@ -290,7 +290,8 @@ requires = ["setuptools", "setuptools_scm[toml]>=6.2", "wheel"]
 [tool.setuptools.packages.find]
 include = ["greetings*"]
 
-[tool.setuptools_scm]
+# Add setuptools_scm if you need to generate version numbers from the git hash
+#[tool.setuptools_scm]
 
 # %% language="bash"
 # cd greetings_repo
@@ -367,7 +368,8 @@ requires = ["setuptools", "setuptools_scm[toml]>=6.2", "wheel"]
 [tool.setuptools.packages.find]
 include = ["greetings*"]
 
-[tool.setuptools_scm]
+# Add setuptools_scm if you need to generate version numbers from the git hash
+#[tool.setuptools_scm]
 
 # %% [markdown]
 # When installing the package now, pip will also install the dependencies automatically.
@@ -625,7 +627,8 @@ requires = ["setuptools", "setuptools_scm[toml]>=6.2", "wheel"]
 include = ["greetings*"]
 exclude = ["tests*"]
 
-[tool.setuptools_scm]
+# Add setuptools_scm if you need to generate version numbers from the git hash
+#[tool.setuptools_scm]
 
 # %% [markdown]
 # ### Developer Install


### PR DESCRIPTION
`setuptools_scm` needs that the package is in a git repository. The way the notes are built locally diverges, somehow, of when it's built on gh actions. Locally, I believe it detects this repository, whereas on gh actions somehow it doesn't and it fails.

Decided to comment out that line with a comment saying to use it when in a git repository.