### PR TITLE
fix: split deployment job and give it write permission

### DIFF
--- a/.github/workflows/build_site.yml
+++ b/.github/workflows/build_site.yml
@@ -1,4 +1,4 @@
-name: Build website
+name: Build and deploy website
 on:
   push:
     branches:
@@ -6,8 +6,10 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
+
 jobs:
-  Build-website:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -51,10 +53,20 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: _site
+
+  deploy:
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
       - name: Deploy to GitHub Pages
         if: >
-          success()
-          && github.ref == 'refs/heads/main'
+          github.ref == 'refs/heads/main'
           && github.repository == 'UCL/rsd-engineeringcourse'
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/build_site.yml
+++ b/.github/workflows/build_site.yml
@@ -55,6 +55,9 @@ jobs:
           path: _site
 
   deploy:
+    if: >
+      github.ref == 'refs/heads/main'
+      && github.repository == 'UCL/rsd-engineeringcourse'
     needs: build
     permissions:
       pages: write
@@ -65,8 +68,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy to GitHub Pages
-        if: >
-          github.ref == 'refs/heads/main'
-          && github.repository == 'UCL/rsd-engineeringcourse'
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
The new deployment workflow did not work as expected - https://github.com/UCL/rsd-engineeringcourse/actions/runs/10389062533 💀 

This PR fixes it. Passing workflow on my fork - https://github.com/Saransh-cpp/rsd-engineeringcourse/actions/runs/10389554321. Deployed website on my fork - https://saransh-cpp.github.io/rsd-engineeringcourse/.