### PR TITLE
Update 015variables.ipynb.py

### DIFF
--- a/ch01python/015variables.ipynb.py
+++ b/ch01python/015variables.ipynb.py
@@ -128,7 +128,7 @@ scary
 
 # %% [markdown]
 # *Supplementary Materials*: There's more on variables at 
-# [Software Carpentry](https://swcarpentry.github.io/python-novice-inflammation/01-intro/index.html).
+# [Software Carpentry](https://swcarpentry.github.io/python-novice-inflammation/01-intro.html).
 
 # %% [markdown]
 # ## Reassignment and multiple labels


### PR DESCRIPTION
Software Carpentry pages have changed their formats - no longer using index.html for each episode.

This bug was reported by one of our ARC Apprentices taking the course.