### PR TITLE
style: Advertise underscore_separation for function names

### DIFF
--- a/ch05construction/02conventions.ipynb.py
+++ b/ch05construction/02conventions.ipynb.py
@@ -124,14 +124,21 @@ reaction2=(
 # ## Naming Conventions
 
 # %% [markdown]
-# [UpperCamel case](https://en.wikipedia.org/wiki/Camel_case) is used for class names in the following example, while function and variable names follow snake_case (underscore_separation). This convention is widely used in the Python community, as stated in [PEP 8](https://pep8.org/).
+# [Camel case](https://en.wikipedia.org/wiki/Camel_case) is used in the following example, where class name is in UpperCamel, functions in lowerCamel and underscore_separation for variable names.
 
 # %%
 class ClassName:
-    def method_name(variable_name):
+    def methodName(variable_name):
         instance_variable = variable_name
 
 
+# %% [markdown]
+# This other example uses underscore_separation for variable and function names, and CamelCase for class names. This convention is used broadly in the python community.
+
+# %%
+class ClassName:
+    def method_name(a_variable):
+        m_instance_variable = a_variable
 # %% [markdown]
 # ## Hungarian Notation
 

--- a/ch05construction/02conventions.ipynb.py
+++ b/ch05construction/02conventions.ipynb.py
@@ -124,21 +124,12 @@ reaction2=(
 # ## Naming Conventions
 
 # %% [markdown]
-# [Camel case](https://en.wikipedia.org/wiki/Camel_case) is used in the following example, where class name is in UpperCamel, functions in lowerCamel and underscore_separation for variables names. This convention is used broadly in the python community.
+# [Camel case](https://en.wikipedia.org/wiki/Camel_case) is used for class names in the following example, while function and variable names follow snake_case (underscore_separation). This convention is widely used in the Python community, as stated in [PEP 8](https://pep8.org/).
 
 # %%
 class ClassName:
-    def methodName(variable_name):
+    def method_name(variable_name):
         instance_variable = variable_name
-
-
-# %% [markdown]
-# This other example uses underscore_separation for all the names.
-
-# %%
-class class_name:
-    def method_name(a_variable):
-        m_instance_variable = a_variable
 
 
 # %% [markdown]

--- a/ch05construction/02conventions.ipynb.py
+++ b/ch05construction/02conventions.ipynb.py
@@ -124,7 +124,7 @@ reaction2=(
 # ## Naming Conventions
 
 # %% [markdown]
-# [Camel case](https://en.wikipedia.org/wiki/Camel_case) is used for class names in the following example, while function and variable names follow snake_case (underscore_separation). This convention is widely used in the Python community, as stated in [PEP 8](https://pep8.org/).
+# [UpperCamel case](https://en.wikipedia.org/wiki/Camel_case) is used for class names in the following example, while function and variable names follow snake_case (underscore_separation). This convention is widely used in the Python community, as stated in [PEP 8](https://pep8.org/).
 
 # %%
 class ClassName:


### PR DESCRIPTION
This PR updates the naming conventions section to promote the use of `underscore_separation` for function names, in alignment with [[PEP 8](https://pep8.org/)](https://pep8.org/) guidelines.

Fixes issue: [[UCL/rsd-engineeringcourse#263](https://github.com/UCL/rsd-engineeringcourse/issues/263)](https://github.com/UCL/rsd-engineeringcourse/issues/263)