### PR TITLE
Cython examples are not showing

### DIFF
--- a/.github/python/requirements.txt
+++ b/.github/python/requirements.txt
@@ -5,3 +5,4 @@ jupyter-client==6.1.12
 # https://github.com/jupyter/jupyter_client/issues/637
 git+https://github.com/UCL-ARC-RSEing-with-Python/greeter.git
 line_profiler
+setuptools # seems cython needs distutils for building ipython magic


### PR DESCRIPTION
This adds the dependency that complains it doesn't exists when trying to use it. Before python 3.12 distutils was part of python, not anymore ([PEP632](https://peps.python.org/pep-0632/)).